### PR TITLE
RB-07 — Body Measurements & Progress Photos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@neondatabase/serverless": "^0.10.4",
+        "@vercel/blob": "^0.27.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "commander": "^12.1.0",
@@ -669,6 +670,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2589,6 +2599,22 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-0.27.3.tgz",
+      "integrity": "sha512-WizeAxzOTmv0JL7wOaxvLIU/KdBcrclM1ZUOdSlIZAxsTTTe1jsyBthStLby0Ueh7FnmKYAjLz26qRJTk5SDkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
@@ -2988,6 +3014,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/autoprefixer": {
@@ -5041,6 +5076,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -5199,6 +5257,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6876,6 +6940,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7582,6 +7655,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -7857,6 +7942,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.10.4",
+    "@vercel/blob": "^0.27.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "commander": "^12.1.0",

--- a/src/app/api/progress-photos/[uuid]/route.ts
+++ b/src/app/api/progress-photos/[uuid]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { deleteProgressPhoto } from '@/db/queries';
+import { requireApiKey } from '@/lib/api-auth';
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ uuid: string }> },
+) {
+  const denied = requireApiKey(request);
+  if (denied) return denied;
+
+  const { uuid } = await params;
+  await deleteProgressPhoto(uuid);
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/progress-photos/route.ts
+++ b/src/app/api/progress-photos/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listProgressPhotos, createProgressPhoto } from '@/db/queries';
+import { requireApiKey } from '@/lib/api-auth';
+
+export async function GET(request: NextRequest) {
+  const denied = requireApiKey(request);
+  if (denied) return denied;
+
+  const { searchParams } = new URL(request.url);
+  const limit = parseInt(searchParams.get('limit') ?? '50', 10);
+  const photos = await listProgressPhotos(limit);
+  return NextResponse.json(photos);
+}
+
+export async function POST(request: NextRequest) {
+  const denied = requireApiKey(request);
+  if (denied) return denied;
+
+  const body = await request.json();
+  if (!body.blob_url || !body.pose) {
+    return NextResponse.json({ error: 'blob_url and pose are required' }, { status: 400 });
+  }
+  const photo = await createProgressPhoto({
+    blob_url: body.blob_url,
+    pose: body.pose,
+    notes: body.notes ?? null,
+    taken_at: body.taken_at,
+  });
+  return NextResponse.json(photo, { status: 201 });
+}

--- a/src/app/api/progress-photos/upload/route.ts
+++ b/src/app/api/progress-photos/upload/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { put } from '@vercel/blob';
+import { requireApiKey } from '@/lib/api-auth';
+import { randomUUID } from 'crypto';
+
+export async function POST(request: NextRequest) {
+  const denied = requireApiKey(request);
+  if (denied) return denied;
+
+  const formData = await request.formData();
+  const file = formData.get('file') as File | null;
+  const pose = (formData.get('pose') as string) || 'front';
+
+  if (!file) {
+    return NextResponse.json({ error: 'file is required' }, { status: 400 });
+  }
+
+  const ext = file.name.split('.').pop() ?? 'jpg';
+  const pathname = `progress-photos/${randomUUID()}-${pose}.${ext}`;
+
+  const blob = await put(pathname, file, { access: 'public' });
+
+  return NextResponse.json({ url: blob.url });
+}

--- a/src/app/measurements/page.tsx
+++ b/src/app/measurements/page.tsx
@@ -1,0 +1,510 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import { ChevronLeft, Trash2, Camera, ImageIcon } from 'lucide-react';
+import Link from 'next/link';
+import { useUnit } from '@/context/UnitContext';
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from 'recharts';
+import type { MeasurementLog, ProgressPhoto } from '@/types';
+
+const SITES = [
+  { key: 'waist',     label: 'Waist' },
+  { key: 'hips',      label: 'Hips' },
+  { key: 'upper_arm', label: 'Upper Arm' },
+  { key: 'thigh',     label: 'Thigh' },
+] as const;
+
+type SiteKey = typeof SITES[number]['key'];
+
+function apiHeaders(): HeadersInit {
+  const key = process.env.NEXT_PUBLIC_REBIRTH_API_KEY;
+  return key
+    ? { 'Content-Type': 'application/json', 'X-Api-Key': key }
+    : { 'Content-Type': 'application/json' };
+}
+
+function apiHeadersNoContentType(): HeadersInit {
+  const key = process.env.NEXT_PUBLIC_REBIRTH_API_KEY;
+  return key ? { 'X-Api-Key': key } : {};
+}
+
+function formatDate(isoStr: string) {
+  return new Date(isoStr).toLocaleDateString('en-GB', {
+    day: '2-digit', month: 'short', year: 'numeric',
+  });
+}
+
+function formatChartDate(isoStr: string) {
+  return new Date(isoStr).toLocaleDateString('en-GB', {
+    day: '2-digit', month: 'short',
+  });
+}
+
+function toDateInputValue(d = new Date()) {
+  return d.toISOString().slice(0, 10);
+}
+
+const POSE_GUIDANCE: Record<string, string> = {
+  front: 'Face the camera, arms slightly away from your body, feet hip-width apart.',
+  side:  'Stand sideways, arms relaxed, feet together, looking straight ahead.',
+  back:  'Back to the camera, arms slightly away from your body, feet hip-width apart.',
+};
+
+export default function MeasurementsPage() {
+  const { fromInput, label } = useUnit();
+  const [activeTab, setActiveTab] = useState<'measurements' | 'photos'>('measurements');
+
+  // Measurements state
+  const [date, setDate] = useState(toDateInputValue);
+  const [inputs, setInputs] = useState<Partial<Record<SiteKey, string>>>({});
+  const [weightInput, setWeightInput] = useState('');
+  const [logs, setLogs] = useState<MeasurementLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [chartSite, setChartSite] = useState<SiteKey>('waist');
+
+  // Photos state
+  const [photos, setPhotos] = useState<ProgressPhoto[]>([]);
+  const [photosLoading, setPhotosLoading] = useState(true);
+  const [selectedPose, setSelectedPose] = useState<'front' | 'side' | 'back'>('front');
+  const [photoNote, setPhotoNote] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    fetch('/api/measurements?limit=90', { headers: apiHeaders() })
+      .then(r => r.json())
+      .then((data: MeasurementLog[]) => { setLogs(data); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetch('/api/progress-photos?limit=50', { headers: apiHeaders() })
+      .then(r => r.json())
+      .then((data: ProgressPhoto[]) => { setPhotos(data); setPhotosLoading(false); })
+      .catch(() => setPhotosLoading(false));
+  }, []);
+
+  const handleSaveMeasurements = async () => {
+    const hasAny = SITES.some(s => inputs[s.key]) || !!weightInput;
+    if (!hasAny) return;
+    setSaving(true);
+    try {
+      const measured_at = date ? new Date(date).toISOString() : undefined;
+      const promises: Promise<Response>[] = [];
+
+      for (const site of SITES) {
+        const val = inputs[site.key];
+        if (val) {
+          promises.push(fetch('/api/measurements', {
+            method: 'POST',
+            headers: apiHeaders(),
+            body: JSON.stringify({ site: site.key, value_cm: parseFloat(val), measured_at }),
+          }));
+        }
+      }
+
+      if (weightInput) {
+        promises.push(fetch('/api/bodyweight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ weight_kg: fromInput(parseFloat(weightInput)) }),
+        }));
+      }
+
+      const responses = await Promise.all(promises);
+      const newLogs: MeasurementLog[] = [];
+      for (const res of responses) {
+        if (res.ok) {
+          const ct = res.headers.get('content-type') ?? '';
+          if (ct.includes('application/json')) {
+            const data = await res.json();
+            if (data.site) newLogs.push(data as MeasurementLog);
+          }
+        }
+      }
+
+      if (newLogs.length > 0) {
+        setLogs(prev => [...newLogs, ...prev]);
+      }
+      setInputs({});
+      setWeightInput('');
+      setDate(toDateInputValue());
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDeleteMeasurement = async (uuid: string) => {
+    await fetch(`/api/measurements/${uuid}`, { method: 'DELETE', headers: apiHeaders() });
+    setLogs(prev => prev.filter(l => l.uuid !== uuid));
+  };
+
+  const handlePhotoUpload = async (file: File) => {
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('pose', selectedPose);
+
+      const uploadRes = await fetch('/api/progress-photos/upload', {
+        method: 'POST',
+        headers: apiHeadersNoContentType(),
+        body: formData,
+      });
+      if (!uploadRes.ok) return;
+      const { url } = await uploadRes.json();
+
+      const res = await fetch('/api/progress-photos', {
+        method: 'POST',
+        headers: apiHeaders(),
+        body: JSON.stringify({ blob_url: url, pose: selectedPose, notes: photoNote || null }),
+      });
+      if (res.ok) {
+        const photo: ProgressPhoto = await res.json();
+        setPhotos(prev => [photo, ...prev]);
+        setPhotoNote('');
+      }
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDeletePhoto = async (uuid: string) => {
+    await fetch(`/api/progress-photos/${uuid}`, { method: 'DELETE', headers: apiHeaders() });
+    setPhotos(prev => prev.filter(p => p.uuid !== uuid));
+  };
+
+  // Chart data: last 30 entries for the selected site, oldest first
+  const chartData = logs
+    .filter(l => l.site === chartSite)
+    .slice(0, 30)
+    .reverse()
+    .map(l => ({
+      date: formatChartDate(l.measured_at),
+      value: parseFloat(String(l.value_cm)),
+    }));
+
+  // Most recent value per site (for snapshot row)
+  const latestBySite: Partial<Record<SiteKey, MeasurementLog>> = {};
+  for (const log of logs) {
+    const s = log.site as SiteKey;
+    if (SITES.find(si => si.key === s) && !latestBySite[s]) {
+      latestBySite[s] = log;
+    }
+  }
+
+  const hasInput = SITES.some(s => inputs[s.key]) || !!weightInput;
+
+  return (
+    <main className="tab-content bg-background">
+      <div className="px-4 pt-14 pb-4 flex items-center gap-3">
+        <Link href="/settings" className="text-primary p-1 -ml-1">
+          <ChevronLeft className="h-5 w-5" />
+        </Link>
+        <h1 className="text-2xl font-bold">Measurements</h1>
+      </div>
+
+      {/* Tab switcher */}
+      <div className="flex border-b border-border mx-4 mb-4">
+        {(['measurements', 'photos'] as const).map(tab => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`flex-1 py-2 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === tab
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground'
+            }`}
+          >
+            {tab === 'measurements' ? 'Measurements' : 'Photos'}
+          </button>
+        ))}
+      </div>
+
+      <div className="px-4 pb-8 space-y-4">
+
+        {activeTab === 'measurements' && (
+          <>
+            {/* Current snapshot */}
+            {(Object.keys(latestBySite).length > 0) && (
+              <div>
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Current</p>
+                <div className="ios-section">
+                  <div className="ios-row flex-wrap gap-x-6 gap-y-2 py-2">
+                    {SITES.filter(s => latestBySite[s.key]).map(s => (
+                      <div key={s.key} className="flex flex-col">
+                        <span className="text-xs text-muted-foreground">{s.label}</span>
+                        <span className="text-sm font-medium">{latestBySite[s.key]!.value_cm} cm</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Log new entry */}
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Log Entry</p>
+              <div className="ios-section">
+                <div className="ios-row justify-between">
+                  <span className="text-sm text-muted-foreground">Date</span>
+                  <input
+                    type="date"
+                    value={date}
+                    onChange={e => setDate(e.target.value)}
+                    className="bg-transparent text-sm text-right outline-none min-h-[44px] text-muted-foreground"
+                  />
+                </div>
+                <div className="ios-row flex-wrap gap-3">
+                  {SITES.map(s => (
+                    <input
+                      key={s.key}
+                      type="number"
+                      inputMode="decimal"
+                      placeholder={`${s.label} (cm)`}
+                      value={inputs[s.key] ?? ''}
+                      onChange={e => setInputs(prev => ({ ...prev, [s.key]: e.target.value }))}
+                      className="flex-1 min-w-[110px] bg-transparent text-sm outline-none min-h-[44px]"
+                    />
+                  ))}
+                </div>
+                <div className="ios-row">
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    placeholder={`Weight (${label})`}
+                    value={weightInput}
+                    onChange={e => setWeightInput(e.target.value)}
+                    className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
+                  />
+                </div>
+                <div className="ios-row justify-end">
+                  <button
+                    onClick={handleSaveMeasurements}
+                    disabled={saving || !hasInput}
+                    className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
+                  >
+                    {saving ? 'Saving…' : 'Save'}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Trend chart */}
+            {!loading && logs.length > 1 && (
+              <div>
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Trend</p>
+                <div className="ios-section">
+                  <div className="ios-row flex-wrap gap-2 py-1">
+                    {SITES.map(s => (
+                      <button
+                        key={s.key}
+                        onClick={() => setChartSite(s.key)}
+                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                          chartSite === s.key
+                            ? 'bg-primary text-white border-primary'
+                            : 'border-border text-muted-foreground'
+                        }`}
+                      >
+                        {s.label}
+                      </button>
+                    ))}
+                  </div>
+                  {chartData.length > 1 ? (
+                    <div className="px-1 py-2">
+                      <ResponsiveContainer width="100%" height={160}>
+                        <LineChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: -20 }}>
+                          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                          <XAxis
+                            dataKey="date"
+                            tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                            tickLine={false}
+                            axisLine={false}
+                            interval="preserveStartEnd"
+                          />
+                          <YAxis
+                            tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                            tickLine={false}
+                            axisLine={false}
+                            domain={['auto', 'auto']}
+                          />
+                          <Tooltip
+                            contentStyle={{
+                              backgroundColor: 'hsl(var(--card))',
+                              border: '1px solid hsl(var(--border))',
+                              borderRadius: '8px',
+                              fontSize: 12,
+                            }}
+                            formatter={(v) => [`${v} cm`, SITES.find(s => s.key === chartSite)?.label ?? chartSite]}
+                          />
+                          <Line
+                            type="monotone"
+                            dataKey="value"
+                            stroke="hsl(var(--primary))"
+                            strokeWidth={2}
+                            dot={chartData.length <= 10}
+                            activeDot={{ r: 4 }}
+                          />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </div>
+                  ) : (
+                    <p className="text-xs text-muted-foreground px-2 pb-3">Log at least 2 entries for {SITES.find(s => s.key === chartSite)?.label.toLowerCase()} to see a trend.</p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* History */}
+            {!loading && logs.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">History</p>
+                <div className="ios-section">
+                  {logs.slice(0, 30).map((log, i) => (
+                    <div
+                      key={log.uuid}
+                      className={`ios-row justify-between ${i < Math.min(logs.length, 30) - 1 ? 'border-b border-border' : ''}`}
+                    >
+                      <div className="flex-1 min-w-0">
+                        <span className="text-sm font-medium">
+                          {SITES.find(s => s.key === log.site)?.label ?? log.site}
+                        </span>
+                        <span className="text-sm text-muted-foreground ml-2">{log.value_cm} cm</span>
+                      </div>
+                      <span className="text-xs text-muted-foreground mr-3">
+                        {formatDate(log.measured_at)}
+                      </span>
+                      <button
+                        onClick={() => handleDeleteMeasurement(log.uuid)}
+                        className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {!loading && logs.length === 0 && (
+              <p className="text-xs text-muted-foreground px-1">No measurements logged yet.</p>
+            )}
+          </>
+        )}
+
+        {activeTab === 'photos' && (
+          <>
+            {/* Upload */}
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Add Photo</p>
+              <div className="ios-section">
+                {/* Pose selector */}
+                <div className="ios-row gap-2">
+                  {(['front', 'side', 'back'] as const).map(pose => (
+                    <button
+                      key={pose}
+                      onClick={() => setSelectedPose(pose)}
+                      className={`flex-1 py-2 text-sm font-medium rounded-lg border capitalize transition-colors ${
+                        selectedPose === pose
+                          ? 'bg-primary text-white border-primary'
+                          : 'border-border text-muted-foreground'
+                      }`}
+                    >
+                      {pose}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Pose guidance */}
+                <div className="ios-row py-1">
+                  <p className="text-xs text-muted-foreground">{POSE_GUIDANCE[selectedPose]}</p>
+                </div>
+
+                {/* Note */}
+                <div className="ios-row">
+                  <input
+                    type="text"
+                    placeholder="Note (optional)"
+                    value={photoNote}
+                    onChange={e => setPhotoNote(e.target.value)}
+                    className="flex-1 bg-transparent text-sm outline-none min-h-[44px] text-muted-foreground"
+                  />
+                </div>
+
+                <div className="ios-row justify-end">
+                  <input
+                    ref={fileRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={e => {
+                      const file = e.target.files?.[0];
+                      if (file) handlePhotoUpload(file);
+                      e.target.value = '';
+                    }}
+                  />
+                  <button
+                    onClick={() => fileRef.current?.click()}
+                    disabled={uploading}
+                    className="flex items-center gap-2 px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
+                  >
+                    <Camera className="h-4 w-4" />
+                    {uploading ? 'Uploading…' : 'Choose Photo'}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Gallery */}
+            {!photosLoading && photos.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Gallery</p>
+                <div className="space-y-3">
+                  {photos.map(photo => (
+                    <div key={photo.uuid} className="ios-section overflow-hidden">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={photo.blob_url}
+                        alt={`${photo.pose} progress photo`}
+                        className="w-full object-cover max-h-[420px] rounded-t-xl"
+                      />
+                      <div className="ios-row justify-between">
+                        <div className="flex flex-col">
+                          <span className="text-sm font-medium capitalize">{photo.pose}</span>
+                          {photo.notes && (
+                            <span className="text-xs text-muted-foreground">{photo.notes}</span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-muted-foreground">{formatDate(photo.taken_at)}</span>
+                          <button
+                            onClick={() => handleDeletePhoto(photo.uuid)}
+                            className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {!photosLoading && photos.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+                <ImageIcon className="h-12 w-12 mb-3 opacity-20" />
+                <p className="text-sm">No progress photos yet.</p>
+                <p className="text-xs mt-1">Upload your first photo above.</p>
+              </div>
+            )}
+          </>
+        )}
+
+      </div>
+    </main>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -119,6 +119,10 @@ export default function SettingsPage() {
               <span className="text-sm font-medium">Body Spec</span>
               <ChevronRight className="h-4 w-4 text-muted-foreground" />
             </Link>
+            <Link href="/measurements" className="ios-row justify-between">
+              <span className="text-sm font-medium">Measurements & Photos</span>
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            </Link>
             <Link href="/nutrition" className="ios-row justify-between">
               <span className="text-sm font-medium">Nutrition</span>
               <ChevronRight className="h-4 w-4 text-muted-foreground" />

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -17,6 +17,7 @@ import type {
   NutritionDayNote,
   HrtLog,
   WellbeingLog,
+  ProgressPhoto,
 } from '../types';
 import { calculatePRs } from '../lib/pr';
 
@@ -1509,4 +1510,43 @@ export async function updateWellbeingLog(uuid: string, data: Partial<Omit<Wellbe
 
 export async function deleteWellbeingLog(uuid: string): Promise<void> {
   await query(`DELETE FROM wellbeing_logs WHERE uuid = $1`, [uuid]);
+}
+
+// ===== PROGRESS PHOTOS (Module 7) =====
+
+function parseProgressPhoto(row: DbRow): ProgressPhoto {
+  return {
+    uuid: row.uuid as string,
+    blob_url: row.blob_url as string,
+    pose: row.pose as ProgressPhoto['pose'],
+    notes: row.notes as string | null,
+    taken_at: row.taken_at as string,
+  };
+}
+
+export async function createProgressPhoto(data: {
+  blob_url: string;
+  pose: string;
+  notes?: string | null;
+  taken_at?: string;
+}): Promise<ProgressPhoto> {
+  const uuid = randomUUID();
+  const row = await queryOne(
+    `INSERT INTO progress_photos (uuid, blob_url, pose, notes, taken_at)
+     VALUES ($1, $2, $3, $4, COALESCE($5::TIMESTAMP, NOW())) RETURNING *`,
+    [uuid, data.blob_url, data.pose, data.notes ?? null, data.taken_at ?? null],
+  );
+  return parseProgressPhoto(row!);
+}
+
+export async function listProgressPhotos(limit = 50): Promise<ProgressPhoto[]> {
+  const rows = await query(
+    `SELECT * FROM progress_photos ORDER BY taken_at DESC LIMIT $1`,
+    [limit],
+  );
+  return rows.map(parseProgressPhoto);
+}
+
+export async function deleteProgressPhoto(uuid: string): Promise<void> {
+  await query(`DELETE FROM progress_photos WHERE uuid = $1`, [uuid]);
 }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -231,3 +231,15 @@ CREATE TABLE IF NOT EXISTS wellbeing_logs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_wellbeing_logs_logged_at ON wellbeing_logs(logged_at DESC);
+
+-- Module 7: Progress photos
+CREATE TABLE IF NOT EXISTS progress_photos (
+  uuid TEXT PRIMARY KEY,
+  blob_url TEXT NOT NULL,
+  pose TEXT NOT NULL CHECK(pose IN ('front', 'side', 'back')),
+  notes TEXT,
+  taken_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_progress_photos_taken_at ON progress_photos(taken_at DESC);

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,3 +202,14 @@ export interface WellbeingLog {
   stress: number | null;     // 1–10
   notes: string | null;
 }
+
+// Module 7: Progress photos
+export type ProgressPhotoPose = 'front' | 'side' | 'back';
+
+export interface ProgressPhoto {
+  uuid: string;
+  blob_url: string;
+  pose: ProgressPhotoPose;
+  notes: string | null;
+  taken_at: string;
+}


### PR DESCRIPTION
## Summary
- **`/measurements` page** with two tabs: Measurements and Photos
- **Measurements tab**: log waist/hips/upper arm/thigh (cm) + weight per date, trend line chart per site, history with delete
- **Photos tab**: pose selector (Front/Side/Back) with guidance text, file upload → Vercel Blob, timeline gallery
- **New schema**: `progress_photos` table with blob_url, pose, notes, taken_at
- **API routes**: `GET/POST /api/progress-photos`, `DELETE /api/progress-photos/[uuid]`, `POST /api/progress-photos/upload`
- **Settings** → "Measurements & Photos" link added
- `@vercel/blob` added as dependency (requires `BLOB_READ_WRITE_TOKEN` env var on Vercel)

## Test plan
- [ ] Visit Settings → Measurements & Photos → lands on `/measurements`
- [ ] Log measurements (waist/hips/upper arm/thigh) for a date → saved, appears in history
- [ ] Log multiple entries for same site → trend chart appears, site selector works
- [ ] Delete a measurement entry
- [ ] Switch to Photos tab → pose selector + guidance text visible
- [ ] Upload a photo → appears in gallery with pose label and date
- [ ] Delete a photo from gallery
- [ ] Run schema migration (`npm run db:migrate`) to create `progress_photos` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)