### PR TITLE
RB-12 — Final integration: cross-module timeline + Vercel deploy

### DIFF
--- a/src/app/api/timeline/route.ts
+++ b/src/app/api/timeline/route.ts
@@ -1,0 +1,217 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { query } from '@/db/db';
+
+export type TimelineModule =
+  | 'workout'
+  | 'nutrition'
+  | 'hrt'
+  | 'measurement'
+  | 'wellbeing'
+  | 'photo'
+  | 'bodyweight'
+  | 'body_spec'
+  | 'dysphoria';
+
+export interface TimelineEntry {
+  id: string;
+  module: TimelineModule;
+  icon: string;
+  timestamp: string;
+  summary: string;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const days = Math.min(parseInt(searchParams.get('days') ?? '30'), 90);
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '50'), 200);
+
+  const since = new Date();
+  since.setDate(since.getDate() - days);
+  const sinceIso = since.toISOString();
+
+  const [
+    workoutRows,
+    nutritionRows,
+    hrtRows,
+    measurementRows,
+    wellbeingRows,
+    photoRows,
+    bodyweightRows,
+    bodySpecRows,
+    dysphoriaRows,
+  ] = await Promise.all([
+    // Workouts (completed only)
+    query<{ uuid: string; start_time: string; title: string | null; exercise_count: number }>(
+      `SELECT w.uuid, w.start_time, w.title,
+        COUNT(DISTINCT we.uuid)::int AS exercise_count
+       FROM workouts w
+       LEFT JOIN workout_exercises we ON we.workout_uuid = w.uuid
+       WHERE w.end_time IS NOT NULL AND w.is_current = false
+         AND w.start_time >= $1
+       GROUP BY w.uuid
+       ORDER BY w.start_time DESC`,
+      [sinceIso]
+    ),
+    // Nutrition logs
+    query<{ uuid: string; logged_at: string; meal_name: string | null; meal_type: string | null; calories: number | null; protein_g: number | null }>(
+      `SELECT uuid, logged_at, meal_name, meal_type, calories, protein_g
+       FROM nutrition_logs WHERE logged_at >= $1 ORDER BY logged_at DESC`,
+      [sinceIso]
+    ),
+    // HRT logs
+    query<{ uuid: string; logged_at: string; medication: string; dose_mg: number | null; taken: boolean }>(
+      `SELECT uuid, logged_at, medication, dose_mg, taken
+       FROM hrt_logs WHERE logged_at >= $1 ORDER BY logged_at DESC`,
+      [sinceIso]
+    ),
+    // Measurement logs
+    query<{ uuid: string; measured_at: string; site: string; value_cm: number }>(
+      `SELECT uuid, measured_at, site, value_cm
+       FROM measurement_logs WHERE measured_at >= $1 ORDER BY measured_at DESC`,
+      [sinceIso]
+    ),
+    // Wellbeing logs
+    query<{ uuid: string; logged_at: string; mood: number | null; energy: number | null; sleep_hours: number | null }>(
+      `SELECT uuid, logged_at, mood, energy, sleep_hours
+       FROM wellbeing_logs WHERE logged_at >= $1 ORDER BY logged_at DESC`,
+      [sinceIso]
+    ),
+    // Progress photos
+    query<{ uuid: string; taken_at: string; pose: string }>(
+      `SELECT uuid, taken_at, pose
+       FROM progress_photos WHERE taken_at >= $1 ORDER BY taken_at DESC`,
+      [sinceIso]
+    ),
+    // Bodyweight logs
+    query<{ uuid: string; logged_at: string; weight_kg: number }>(
+      `SELECT uuid, logged_at, weight_kg
+       FROM bodyweight_logs WHERE logged_at >= $1 ORDER BY logged_at DESC`,
+      [sinceIso]
+    ),
+    // Body spec logs
+    query<{ uuid: string; measured_at: string; weight_kg: number | null; body_fat_pct: number | null }>(
+      `SELECT uuid, measured_at, weight_kg, body_fat_pct
+       FROM body_spec_logs WHERE measured_at >= $1 ORDER BY measured_at DESC`,
+      [sinceIso]
+    ),
+    // Dysphoria logs
+    query<{ uuid: string; logged_at: string; scale: number }>(
+      `SELECT uuid, logged_at, scale
+       FROM dysphoria_logs WHERE logged_at >= $1 ORDER BY logged_at DESC`,
+      [sinceIso]
+    ),
+  ]);
+
+  const entries: TimelineEntry[] = [];
+
+  for (const w of workoutRows) {
+    const ex = w.exercise_count;
+    entries.push({
+      id: w.uuid,
+      module: 'workout',
+      icon: 'dumbbell',
+      timestamp: w.start_time,
+      summary: w.title
+        ? `${w.title} · ${ex} exercise${ex !== 1 ? 's' : ''}`
+        : `Workout · ${ex} exercise${ex !== 1 ? 's' : ''}`,
+    });
+  }
+
+  for (const n of nutritionRows) {
+    const name = n.meal_name ?? n.meal_type ?? 'Meal';
+    const parts = [];
+    if (n.calories) parts.push(`${Math.round(n.calories)} kcal`);
+    if (n.protein_g) parts.push(`${Math.round(n.protein_g)}g protein`);
+    entries.push({
+      id: n.uuid,
+      module: 'nutrition',
+      icon: 'utensils',
+      timestamp: n.logged_at,
+      summary: parts.length ? `${name} · ${parts.join(', ')}` : name,
+    });
+  }
+
+  for (const h of hrtRows) {
+    const dose = h.dose_mg ? ` ${h.dose_mg}mg` : '';
+    entries.push({
+      id: h.uuid,
+      module: 'hrt',
+      icon: 'pill',
+      timestamp: h.logged_at,
+      summary: `${h.medication}${dose} · ${h.taken ? 'taken' : 'skipped'}`,
+    });
+  }
+
+  for (const m of measurementRows) {
+    entries.push({
+      id: m.uuid,
+      module: 'measurement',
+      icon: 'ruler',
+      timestamp: m.measured_at,
+      summary: `${m.site.replace(/_/g, ' ')} · ${m.value_cm} cm`,
+    });
+  }
+
+  for (const wb of wellbeingRows) {
+    const parts = [];
+    if (wb.mood != null) parts.push(`mood ${wb.mood}/10`);
+    if (wb.energy != null) parts.push(`energy ${wb.energy}/10`);
+    if (wb.sleep_hours != null) parts.push(`${wb.sleep_hours}h sleep`);
+    entries.push({
+      id: wb.uuid,
+      module: 'wellbeing',
+      icon: 'heart',
+      timestamp: wb.logged_at,
+      summary: parts.length ? `Wellbeing · ${parts.join(', ')}` : 'Wellbeing check-in',
+    });
+  }
+
+  for (const p of photoRows) {
+    entries.push({
+      id: p.uuid,
+      module: 'photo',
+      icon: 'camera',
+      timestamp: p.taken_at,
+      summary: `Progress photo · ${p.pose}`,
+    });
+  }
+
+  for (const bw of bodyweightRows) {
+    entries.push({
+      id: bw.uuid,
+      module: 'bodyweight',
+      icon: 'scale',
+      timestamp: bw.logged_at,
+      summary: `Bodyweight · ${bw.weight_kg} kg`,
+    });
+  }
+
+  for (const bs of bodySpecRows) {
+    const parts = [];
+    if (bs.weight_kg != null) parts.push(`${bs.weight_kg} kg`);
+    if (bs.body_fat_pct != null) parts.push(`${bs.body_fat_pct}% body fat`);
+    entries.push({
+      id: bs.uuid,
+      module: 'body_spec',
+      icon: 'activity',
+      timestamp: bs.measured_at,
+      summary: parts.length ? `Body scan · ${parts.join(', ')}` : 'Body scan',
+    });
+  }
+
+  for (const d of dysphoriaRows) {
+    const label = d.scale >= 7 ? 'euphoric' : d.scale <= 3 ? 'dysphoric' : 'neutral';
+    entries.push({
+      id: d.uuid,
+      module: 'dysphoria',
+      icon: 'sparkles',
+      timestamp: d.logged_at,
+      summary: `Dysphoria check · ${d.scale}/10 (${label})`,
+    });
+  }
+
+  // Merge-sort all entries chronologically descending
+  entries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+  return NextResponse.json(entries.slice(0, limit));
+}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import type { TimelineEntry, TimelineModule } from '../api/timeline/route';
 
 interface StatsData {
   activeDays: string[];
@@ -49,6 +50,18 @@ function formatDate(iso: string): string {
   return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
+function formatTimeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'Yesterday';
+  if (days < 7) return `${days}d ago`;
+  return formatDate(iso);
+}
+
 const MUSCLE_GROUPS = [
   { key: 'chest', label: 'Chest' },
   { key: 'back', label: 'Back' },
@@ -73,15 +86,39 @@ function muscleTextColor(count: number): string {
   return 'text-zinc-500';
 }
 
+// Module chip styling
+const MODULE_STYLES: Record<TimelineModule, { bg: string; text: string; label: string }> = {
+  workout:     { bg: 'bg-blue-900',   text: 'text-blue-300',   label: 'Workout' },
+  nutrition:   { bg: 'bg-green-900',  text: 'text-green-300',  label: 'Nutrition' },
+  hrt:         { bg: 'bg-purple-900', text: 'text-purple-300', label: 'HRT' },
+  measurement: { bg: 'bg-orange-900', text: 'text-orange-300', label: 'Measure' },
+  wellbeing:   { bg: 'bg-pink-900',   text: 'text-pink-300',   label: 'Wellbeing' },
+  photo:       { bg: 'bg-yellow-900', text: 'text-yellow-300', label: 'Photo' },
+  bodyweight:  { bg: 'bg-cyan-900',   text: 'text-cyan-300',   label: 'Weight' },
+  body_spec:   { bg: 'bg-teal-900',   text: 'text-teal-300',   label: 'Body Scan' },
+  dysphoria:   { bg: 'bg-rose-900',   text: 'text-rose-300',   label: 'Dysphoria' },
+};
+
+// Secondary modules with quick-link destinations
+const SECONDARY_MODULES = [
+  { label: 'HRT', href: '/hrt', emoji: '💊' },
+  { label: 'Wellbeing', href: '/wellbeing', emoji: '🫀' },
+  { label: 'Nutrition', href: '/nutrition', emoji: '🥗' },
+  { label: 'Measures', href: '/measurements', emoji: '📏' },
+  { label: 'Photos', href: '/body-spec', emoji: '📸' },
+];
+
 export default function FeedPage() {
   const router = useRouter();
   const [stats, setStats] = useState<StatsData | null>(null);
   const [summary, setSummary] = useState<SummaryData | null>(null);
+  const [timeline, setTimeline] = useState<TimelineEntry[] | null>(null);
   const [startingWorkout, setStartingWorkout] = useState(false);
 
   useEffect(() => {
     fetch('/api/stats').then(r => r.json()).then(setStats);
     fetch('/api/stats/summary').then(r => r.json()).then(setSummary);
+    fetch('/api/timeline?days=30&limit=20').then(r => r.json()).then(setTimeline);
   }, []);
 
   // Build 28-day grid (4 weeks × 7 days), starting from 27 days ago
@@ -106,6 +143,27 @@ export default function FeedPage() {
 
   // Day-of-week headers (Sun–Sat)
   const dayHeaders = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+  // Today at a Glance: which modules have an entry today
+  const todayIso = isoDate(today);
+  const todayModules = new Set<string>();
+  if (timeline) {
+    for (const entry of timeline) {
+      if (entry.timestamp.startsWith(todayIso)) {
+        todayModules.add(entry.module);
+      }
+    }
+  }
+  // Check workouts separately from stats activeDays
+  if (activeDaySet.has(todayIso)) todayModules.add('workout');
+
+  const glanceItems = [
+    { key: 'workout',   label: 'Train',    emoji: '🏋️' },
+    { key: 'wellbeing', label: 'Wellbeing', emoji: '🫀' },
+    { key: 'hrt',       label: 'HRT',      emoji: '💊' },
+    { key: 'nutrition', label: 'Food',     emoji: '🥗' },
+    { key: 'measurement', label: 'Measure', emoji: '📏' },
+  ];
 
   async function handleQuickStart() {
     setStartingWorkout(true);
@@ -159,6 +217,30 @@ export default function FeedPage() {
 
       <div className="px-4 space-y-4 pb-4">
 
+        {/* Today at a Glance */}
+        <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
+          <span className="text-xs font-semibold text-primary uppercase tracking-wide">Today at a Glance</span>
+          <div className="flex gap-2 mt-3 flex-wrap">
+            {glanceItems.map(({ key, label, emoji }) => {
+              const done = todayModules.has(key);
+              return (
+                <div
+                  key={key}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                    done
+                      ? 'bg-primary text-white'
+                      : 'bg-zinc-800 text-zinc-500 border border-zinc-700'
+                  }`}
+                >
+                  <span>{emoji}</span>
+                  <span>{label}</span>
+                  {done && <span className="text-white/80">✓</span>}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
         {/* Weekly Summary Card */}
         <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
           <span className="text-xs font-semibold text-primary uppercase tracking-wide">This Week</span>
@@ -202,6 +284,23 @@ export default function FeedPage() {
           )}
         </div>
 
+        {/* Secondary Module Quick-Links */}
+        <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
+          <span className="text-xs font-semibold text-primary uppercase tracking-wide">Modules</span>
+          <div className="grid grid-cols-5 gap-2 mt-3">
+            {SECONDARY_MODULES.map(({ label, href, emoji }) => (
+              <button
+                key={href}
+                onClick={() => router.push(href)}
+                className="flex flex-col items-center gap-1.5 py-3 rounded-xl bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 active:scale-95 transition-all"
+              >
+                <span className="text-xl">{emoji}</span>
+                <span className="text-[10px] font-medium text-zinc-400">{label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
         {/* Last 3 Workouts */}
         {(summary?.lastWorkouts?.length ?? 0) > 0 && (
           <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
@@ -231,6 +330,35 @@ export default function FeedPage() {
             </div>
           </div>
         )}
+
+        {/* Cross-module Timeline */}
+        <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
+          <span className="text-xs font-semibold text-primary uppercase tracking-wide">Timeline</span>
+          <div className="mt-3 space-y-2">
+            {timeline === null ? (
+              <div className="text-center py-6 text-zinc-600 text-sm">Loading…</div>
+            ) : timeline.length === 0 ? (
+              <div className="text-center py-6 text-zinc-600 text-sm">No activity in the last 30 days</div>
+            ) : (
+              timeline.map((entry) => {
+                const style = MODULE_STYLES[entry.module];
+                return (
+                  <div key={`${entry.module}-${entry.id}`} className="flex items-start gap-3">
+                    <div className="flex-shrink-0 mt-0.5">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold ${style.bg} ${style.text}`}>
+                        {style.label}
+                      </span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-zinc-200 truncate">{entry.summary}</p>
+                      <p className="text-[11px] text-zinc-500">{formatTimeAgo(entry.timestamp)}</p>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
 
         {/* Muscle Group Heatmap */}
         {summary && (


### PR DESCRIPTION
## Summary

- **`/api/timeline`** — New endpoint aggregating all 9 module tables (workouts, nutrition, HRT, measurements, wellbeing, progress photos, bodyweight, body spec, dysphoria) for the last N days, merged and sorted chronologically. Returns typed entries with `module`, `icon`, `timestamp`, and human-readable `summary`.
- **"Today at a Glance"** — Compact checklist row at the top of Feed showing which modules have logged data today (workout / wellbeing / HRT / food / measure). Pills go solid-primary when done.
- **Cross-module Timeline** — Scrollable section on Feed showing last 20 entries across all modules with color-coded module chips and time-ago labels.
- **Secondary module quick-links** — 5-icon grid (HRT, Wellbeing, Nutrition, Measures, Photos) giving one-tap access to modules not in the tab bar.
- **Build verified** — `next build` passes clean: 38 static + 50 dynamic routes.

## Test plan
- [ ] `/api/timeline` returns JSON array sorted by timestamp desc
- [ ] Today at a Glance pills update correctly when modules have entries today
- [ ] Timeline section renders entries with correct module labels and time-ago
- [ ] Quick-link grid routes correctly to each secondary module page
- [ ] Vercel deployment succeeds on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)