### PR TITLE
iPad web-first responsive pass + Dumbbell icon

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,13 @@
+## iPad — future work (deferred from 2026-04-20 web-first pivot)
+
+- [ ] If iPad usage is real, evaluate native universal binary + one wedge feature
+      (Pencil on progress photos OR InBody scan scrub-compare OR weekly review cockpit)
+- [ ] If going native: update FitspoControlExtension + RestTimerLiveActivity
+      device family to 1,2 for widget parity
+- [ ] Consider Stage Manager / keyboard shortcut / macOS Catalyst surfaces at that point
+- [ ] Chart enrichment polish round — currently added reference lines + multi-site overlay
+      at lg:+; consider making trend metric selectable (weight, SMM, BMR) rather than hardcoded PBF%
+- [ ] ios-section / ios-row standardization — both reviewers flagged as visual debt,
+      out of scope for the 2026-04-20 iPad pass
+- [ ] Success metric before graduating to native: N weekly iPad sessions, mostly on
+      /measurements or /body-spec

--- a/TODOS.md
+++ b/TODOS.md
@@ -11,3 +11,10 @@
       out of scope for the 2026-04-20 iPad pass
 - [ ] Success metric before graduating to native: N weekly iPad sessions, mostly on
       /measurements or /body-spec
+
+## UI polish
+
+- [ ] Inspo capture button icon — replace the Camera icon (src/components/InspoCaptureButton.tsx,
+      set in commit d60cecc) with a muscle / flex icon (Lucide has no native "flex" — consider
+      Dumbbell, or revert to 💪 emoji, or build a small custom SVG). Camera reads too "take a
+      photo of my food" and not "fitspo inspiration burst."

--- a/TODOS.md
+++ b/TODOS.md
@@ -12,9 +12,3 @@
 - [ ] Success metric before graduating to native: N weekly iPad sessions, mostly on
       /measurements or /body-spec
 
-## UI polish
-
-- [ ] Inspo capture button icon — replace the Camera icon (src/components/InspoCaptureButton.tsx,
-      set in commit d60cecc) with a muscle / flex icon (Lucide has no native "flex" — consider
-      Dumbbell, or revert to 💪 emoji, or build a small custom SVG). Camera reads too "take a
-      photo of my food" and not "fitspo inspiration burst."

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,6 @@
   "description": "Personal fitness tracker",
   "start_url": "/workout",
   "display": "standalone",
-  "orientation": "portrait",
   "background_color": "#5BCEFA",
   "theme_color": "#5BCEFA",
   "icons": [

--- a/src/app/body-spec/page.tsx
+++ b/src/app/body-spec/page.tsx
@@ -101,17 +101,18 @@ export default function BodySpecPage() {
 
   return (
     <main className="tab-content bg-background">
-      <div className="px-4 pt-safe pb-4 flex items-center gap-3">
-        <Link href="/settings" className="text-primary p-1 -ml-1">
-          <ChevronLeft className="h-5 w-5" />
-        </Link>
-        <h1 className="text-2xl font-bold">Body Spec</h1>
-      </div>
+      <div className="max-w-lg md:max-w-3xl mx-auto">
+        <div className="px-4 pt-safe pb-4 flex items-center gap-3">
+          <Link href="/settings" className="text-primary p-1 -ml-1">
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-2xl font-bold">Body Spec</h1>
+        </div>
 
-      <div className="px-4 space-y-4 pb-8">
+        <div className="px-4 pb-8 grid grid-cols-1 md:grid-cols-3 gap-6 auto-rows-min">
 
-        {/* Log form */}
-        <div>
+        {/* Log form — left column on md:+ */}
+        <div className="md:col-span-1">
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">New Entry</p>
           <div className="ios-section">
             <div className="ios-row gap-3 flex-wrap">
@@ -180,9 +181,9 @@ export default function BodySpecPage() {
           </div>
         </div>
 
-        {/* History */}
+        {/* History — right column on md:+ (spans 2/3) */}
         {!loading && logs.length > 0 && (
-          <div>
+          <div className="md:col-span-2">
             <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">History</p>
             <div className="ios-section">
               {logs.map((log, i) => {
@@ -231,9 +232,10 @@ export default function BodySpecPage() {
         )}
 
         {!loading && logs.length === 0 && (
-          <p className="text-xs text-muted-foreground px-1">No body spec entries yet.</p>
+          <p className="text-xs text-muted-foreground px-1 md:col-span-2">No body spec entries yet.</p>
         )}
 
+        </div>
       </div>
     </main>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,8 +26,6 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
   viewportFit: "cover",
   themeColor: "#5BCEFA",
   /** Reduces resize jank when mobile keyboards open (supported browsers). */

--- a/src/app/measurements/goals/page.tsx
+++ b/src/app/measurements/goals/page.tsx
@@ -93,30 +93,31 @@ export default function BodyGoalsPage() {
 
   return (
     <main className="tab-content bg-background">
-      <div className="px-4 pt-safe pb-4 flex items-center gap-3">
-        <Link href="/measurements" className="text-primary p-1 -ml-1">
-          <ChevronLeft className="h-5 w-5" />
-        </Link>
-        <h1 className="text-2xl font-bold">Body Goals</h1>
-      </div>
+      <div className="max-w-lg md:max-w-4xl mx-auto">
+        <div className="px-4 pt-safe pb-4 flex items-center gap-3">
+          <Link href="/measurements" className="text-primary p-1 -ml-1">
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-2xl font-bold">Body Goals</h1>
+        </div>
 
-      <div className="px-4 pb-20 space-y-4">
-        {loading && <p className="text-xs text-muted-foreground px-1">Loading…</p>}
+        <div className="px-4 pb-20 md:grid md:grid-cols-2 md:gap-4 md:auto-rows-min space-y-4 md:space-y-0">
+          {loading && <p className="text-xs text-muted-foreground px-1 md:col-span-2">Loading…</p>}
 
-        {!loading && !hasAnyGoal && (
-          <p className="text-sm text-muted-foreground px-1">
-            No goals set yet — tap any metric below to set a target.
-          </p>
-        )}
+          {!loading && !hasAnyGoal && (
+            <p className="text-sm text-muted-foreground px-1 md:col-span-2">
+              No goals set yet — tap any metric below to set a target.
+            </p>
+          )}
 
-        {!loading && GROUPS.map(group => {
-          const metrics = METRICS.filter(m => m.group === group);
-          return (
-            <div key={group}>
-              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">
-                {GROUP_LABELS[group]}
-              </p>
-              <div className="ios-section">
+          {!loading && GROUPS.map(group => {
+            const metrics = METRICS.filter(m => m.group === group);
+            return (
+              <div key={group}>
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">
+                  {GROUP_LABELS[group]}
+                </p>
+                <div className="ios-section">
                 {metrics.map(m => {
                   const key = m.key as string;
                   const draft = getDraft(key);
@@ -177,11 +178,12 @@ export default function BodyGoalsPage() {
                       </div>
                     </div>
                   );
-                })}
+                  })}
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
     </main>
   );

--- a/src/app/measurements/inbody/compare/page.tsx
+++ b/src/app/measurements/inbody/compare/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { ChevronLeft } from 'lucide-react';
 import type { InbodyScan } from '@/types';
 import { apiBase } from '@/lib/api/client';
-import { METRICS, GROUP_LABELS, scanValue, formatValue, type MetricGroup } from '@/lib/inbody';
+import { METRICS, GROUP_LABELS, scanValue, formatValue, type MetricGroup, type MetricDef } from '@/lib/inbody';
 
 function apiHeaders(): HeadersInit {
   const key = process.env.NEXT_PUBLIC_REBIRTH_API_KEY;
@@ -16,8 +16,22 @@ function apiHeaders(): HeadersInit {
 
 const GROUPS: MetricGroup[] = ['body_comp', 'derived', 'seg_lean', 'seg_fat', 'circumference', 'recommendation'];
 
+// Metrics summarised in the md:+ center Δ column
+const DELTA_METRIC_KEYS: ReadonlyArray<string> = ['weight_kg', 'pbf_pct', 'smm_kg', 'bmr_kcal'];
+
 function shortDate(iso: string) {
   return new Date(iso).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+function deltaColorClass(m: MetricDef, delta: number | null): string {
+  if (delta == null || delta === 0) return 'text-muted-foreground';
+  if ((m.preferredDirection === 'higher' && delta > 0) || (m.preferredDirection === 'lower' && delta < 0)) {
+    return 'text-emerald-500';
+  }
+  if ((m.preferredDirection === 'higher' && delta < 0) || (m.preferredDirection === 'lower' && delta > 0)) {
+    return 'text-rose-500';
+  }
+  return 'text-muted-foreground';
 }
 
 export default function CompareInbodyScansPage() {
@@ -47,97 +61,146 @@ export default function CompareInbodyScansPage() {
   const a = useMemo(() => scans.find(s => s.uuid === aUuid) ?? null, [scans, aUuid]);
   const b = useMemo(() => scans.find(s => s.uuid === bUuid) ?? null, [scans, bUuid]);
 
+  // Headline deltas for the md:+ center Δ column
+  const headlineDeltas = (a && b) ? DELTA_METRIC_KEYS.map(k => {
+    const metric = METRICS.find(m => m.key === k);
+    if (!metric) return null;
+    const av = scanValue(a, k);
+    const bv = scanValue(b, k);
+    const delta = av != null && bv != null ? bv - av : null;
+    const pct = av != null && bv != null && av !== 0 ? (delta! / Math.abs(av)) * 100 : null;
+    return { metric, av, bv, delta, pct };
+  }).filter(Boolean) as Array<{ metric: MetricDef; av: number | null; bv: number | null; delta: number | null; pct: number | null }> : [];
+
   return (
     <main className="tab-content bg-background">
-      <div className="px-4 pt-safe pb-4 flex items-center gap-3">
-        <Link href="/measurements" className="text-primary p-1 -ml-1">
-          <ChevronLeft className="h-5 w-5" />
-        </Link>
-        <h1 className="text-2xl font-bold">Compare Scans</h1>
-      </div>
-
-      <div className="px-4 pb-20 space-y-4">
-        {/* Scan pickers */}
-        <div className="ios-section">
-          <div className="ios-row justify-between gap-3">
-            <span className="text-sm text-muted-foreground">A</span>
-            <select
-              value={aUuid}
-              onChange={e => setAUuid(e.target.value)}
-              className="bg-transparent text-sm text-right outline-none min-h-[44px] flex-1"
-            >
-              {scans.map(s => (
-                <option key={s.uuid} value={s.uuid}>{shortDate(s.scanned_at)}</option>
-              ))}
-            </select>
-          </div>
-          <div className="ios-row justify-between gap-3">
-            <span className="text-sm text-muted-foreground">B</span>
-            <select
-              value={bUuid}
-              onChange={e => setBUuid(e.target.value)}
-              className="bg-transparent text-sm text-right outline-none min-h-[44px] flex-1"
-            >
-              {scans.map(s => (
-                <option key={s.uuid} value={s.uuid}>{shortDate(s.scanned_at)}</option>
-              ))}
-            </select>
-          </div>
+      <div className="max-w-lg md:max-w-6xl mx-auto">
+        <div className="px-4 pt-safe pb-4 flex items-center gap-3">
+          <Link href="/measurements" className="text-primary p-1 -ml-1">
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-2xl font-bold">Compare Scans</h1>
         </div>
 
-        {(!a || !b) && <p className="text-xs text-muted-foreground px-1">Pick two scans to compare.</p>}
-
-        {a && b && GROUPS.map(group => {
-          const metrics = METRICS.filter(m => m.group === group);
-          const rows = metrics.map(m => {
-            const av = scanValue(a, m.key as string);
-            const bv = scanValue(b, m.key as string);
-            if (av == null && bv == null) return null;
-            const delta = av != null && bv != null ? bv - av : null;
-            const pct = av != null && bv != null && av !== 0 ? (delta! / Math.abs(av)) * 100 : null;
-            return { m, av, bv, delta, pct };
-          }).filter(Boolean) as Array<{ m: (typeof METRICS)[number]; av: number | null; bv: number | null; delta: number | null; pct: number | null }>;
-
-          if (rows.length === 0) return null;
-
-          return (
-            <div key={group}>
-              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">{GROUP_LABELS[group]}</p>
-              <div className="ios-section">
-                <div className="ios-row text-xs text-muted-foreground font-medium">
-                  <span className="flex-1">Metric</span>
-                  <span className="w-20 text-right">A</span>
-                  <span className="w-20 text-right">B</span>
-                  <span className="w-20 text-right">Δ</span>
-                </div>
-                {rows.map(({ m, av, bv, delta, pct }) => {
-                  const dColor = delta == null ? 'text-muted-foreground'
-                    : delta === 0 ? 'text-muted-foreground'
-                    : (m.preferredDirection === 'higher' && delta > 0) || (m.preferredDirection === 'lower' && delta < 0)
-                      ? 'text-emerald-500'
-                      : (m.preferredDirection === 'higher' && delta < 0) || (m.preferredDirection === 'lower' && delta > 0)
-                        ? 'text-rose-500'
-                        : 'text-muted-foreground';
-                  return (
-                    <div key={m.key as string} className="ios-row">
-                      <span className="text-sm flex-1 truncate">{m.label}</span>
-                      <span className="w-20 text-right text-sm">{formatValue(av, m)}</span>
-                      <span className="w-20 text-right text-sm">{formatValue(bv, m)}</span>
-                      <span className={`w-20 text-right text-sm font-medium ${dColor}`}>
-                        {delta == null ? '—' : (
-                          <>
-                            {delta > 0 ? '+' : ''}{delta.toFixed(m.dp ?? 1)}
-                            {pct != null && <span className="block text-[10px] font-normal">{pct > 0 ? '+' : ''}{pct.toFixed(1)}%</span>}
-                          </>
-                        )}
-                      </span>
-                    </div>
-                  );
-                })}
+        <div className="px-4 pb-20 space-y-4">
+          {/* Scan pickers — on md:+ lay out as A | Δ | B row */}
+          <div className="md:flex md:items-stretch md:gap-4">
+            <div className="ios-section md:basis-5/12">
+              <div className="ios-row justify-between gap-3">
+                <span className="text-sm text-muted-foreground">A</span>
+                <select
+                  value={aUuid}
+                  onChange={e => setAUuid(e.target.value)}
+                  className="bg-transparent text-sm text-right outline-none min-h-[44px] flex-1"
+                >
+                  {scans.map(s => (
+                    <option key={s.uuid} value={s.uuid}>{shortDate(s.scanned_at)}</option>
+                  ))}
+                </select>
               </div>
             </div>
-          );
-        })}
+
+            {/* Δ column summary (md:+ only) — headline metric deltas */}
+            <div className="hidden md:block md:basis-2/12">
+              {a && b && headlineDeltas.length > 0 ? (
+                <div className="ios-section h-full">
+                  <div className="ios-row justify-center">
+                    <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Δ</span>
+                  </div>
+                  {headlineDeltas.map(({ metric, delta, pct }) => (
+                    <div key={metric.key as string} className="ios-row flex-col items-center gap-0 py-2">
+                      <span className="text-[10px] text-muted-foreground uppercase tracking-wide">{metric.label}</span>
+                      <span className={`text-sm font-semibold ${deltaColorClass(metric, delta)}`}>
+                        {delta == null ? '—' : `${delta > 0 ? '+' : ''}${delta.toFixed(metric.dp ?? 1)}`}
+                      </span>
+                      {pct != null && (
+                        <span className="text-[10px] text-muted-foreground">
+                          {pct > 0 ? '+' : ''}{pct.toFixed(1)}%
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="h-full" aria-hidden />
+              )}
+            </div>
+
+            <div className="ios-section md:basis-5/12">
+              <div className="ios-row justify-between gap-3">
+                <span className="text-sm text-muted-foreground">B</span>
+                <select
+                  value={bUuid}
+                  onChange={e => setBUuid(e.target.value)}
+                  className="bg-transparent text-sm text-right outline-none min-h-[44px] flex-1"
+                >
+                  {scans.map(s => (
+                    <option key={s.uuid} value={s.uuid}>{shortDate(s.scanned_at)}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+
+          {(!a || !b) && (
+            <div className="md:max-w-2xl mx-auto">
+              <div className="ios-section">
+                <div className="ios-row flex-col items-start gap-2 py-5">
+                  <span className="text-sm font-semibold">Pick two scans to compare</span>
+                  <span className="text-xs text-muted-foreground">
+                    Use the dropdowns above to choose two InBody scans — we&apos;ll surface the delta across every tracked metric.
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {a && b && GROUPS.map(group => {
+            const metrics = METRICS.filter(m => m.group === group);
+            const rows = metrics.map(m => {
+              const av = scanValue(a, m.key as string);
+              const bv = scanValue(b, m.key as string);
+              if (av == null && bv == null) return null;
+              const delta = av != null && bv != null ? bv - av : null;
+              const pct = av != null && bv != null && av !== 0 ? (delta! / Math.abs(av)) * 100 : null;
+              return { m, av, bv, delta, pct };
+            }).filter(Boolean) as Array<{ m: (typeof METRICS)[number]; av: number | null; bv: number | null; delta: number | null; pct: number | null }>;
+
+            if (rows.length === 0) return null;
+
+            return (
+              <div key={group}>
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">{GROUP_LABELS[group]}</p>
+                <div className="ios-section">
+                  <div className="ios-row text-xs text-muted-foreground font-medium">
+                    <span className="flex-1">Metric</span>
+                    <span className="w-20 text-right">A</span>
+                    <span className="w-20 text-right">B</span>
+                    <span className="w-20 text-right">Δ</span>
+                  </div>
+                  {rows.map(({ m, av, bv, delta, pct }) => {
+                    const dColor = deltaColorClass(m, delta);
+                    return (
+                      <div key={m.key as string} className="ios-row">
+                        <span className="text-sm flex-1 truncate">{m.label}</span>
+                        <span className="w-20 text-right text-sm">{formatValue(av, m)}</span>
+                        <span className="w-20 text-right text-sm">{formatValue(bv, m)}</span>
+                        <span className={`w-20 text-right text-sm font-medium ${dColor}`}>
+                          {delta == null ? '—' : (
+                            <>
+                              {delta > 0 ? '+' : ''}{delta.toFixed(m.dp ?? 1)}
+                              {pct != null && <span className="block text-[10px] font-normal">{pct > 0 ? '+' : ''}{pct.toFixed(1)}%</span>}
+                            </>
+                          )}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </main>
   );

--- a/src/app/measurements/inbody/detail/page.tsx
+++ b/src/app/measurements/inbody/detail/page.tsx
@@ -68,13 +68,25 @@ function InbodyScanDetailInner() {
   if (loading) {
     return (
       <main className="tab-content bg-background">
-        <div className="px-4 pt-safe pb-4 flex items-center gap-3">
-          <Link href="/measurements" className="text-primary p-1 -ml-1">
-            <ChevronLeft className="h-5 w-5" />
-          </Link>
-          <h1 className="text-2xl font-bold">InBody Scan</h1>
+        <div className="max-w-lg md:max-w-6xl mx-auto px-4 md:px-0">
+          <div className="px-4 md:px-0 pt-safe pb-4 flex items-center gap-3">
+            <Link href="/measurements" className="text-primary p-1 -ml-1">
+              <ChevronLeft className="h-5 w-5" />
+            </Link>
+            <h1 className="text-2xl font-bold">InBody Scan</h1>
+          </div>
+          {/* Skeleton matching the eventual 2-col metric grid */}
+          <div className="px-4 md:px-0 grid grid-cols-1 md:grid-cols-4 gap-6 auto-rows-min">
+            <div className="md:col-span-1">
+              <div className="rounded-2xl bg-card border border-border p-4 h-32 animate-pulse" aria-hidden />
+            </div>
+            <div className="md:col-span-3 grid grid-cols-1 md:grid-cols-2 gap-4 auto-rows-min">
+              {[0, 1, 2, 3].map(i => (
+                <div key={i} className="rounded-xl bg-card border border-border h-40 animate-pulse" aria-hidden />
+              ))}
+            </div>
+          </div>
         </div>
-        <p className="px-4 text-sm text-muted-foreground">Loading…</p>
       </main>
     );
   }
@@ -82,11 +94,13 @@ function InbodyScanDetailInner() {
   if (!scan) {
     return (
       <main className="tab-content bg-background">
-        <div className="px-4 pt-safe pb-4 flex items-center gap-3">
-          <Link href="/measurements" className="text-primary p-1 -ml-1">
-            <ChevronLeft className="h-5 w-5" />
-          </Link>
-          <h1 className="text-2xl font-bold">Not Found</h1>
+        <div className="max-w-lg md:max-w-6xl mx-auto">
+          <div className="px-4 pt-safe pb-4 flex items-center gap-3">
+            <Link href="/measurements" className="text-primary p-1 -ml-1">
+              <ChevronLeft className="h-5 w-5" />
+            </Link>
+            <h1 className="text-2xl font-bold">Not Found</h1>
+          </div>
         </div>
       </main>
     );
@@ -96,131 +110,156 @@ function InbodyScanDetailInner() {
     day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit',
   });
 
+  const balanceBlock = (scan.balance_upper || scan.balance_lower || scan.balance_upper_lower) ? (
+    <div>
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Body Balance</p>
+      <div className="ios-section">
+        {([
+          ['Upper', scan.balance_upper],
+          ['Lower', scan.balance_lower],
+          ['Upper–Lower', scan.balance_upper_lower],
+        ] as const).map(([label, val]) => val ? (
+          <div key={label} className="ios-row justify-between">
+            <span className="text-sm text-muted-foreground">{label}</span>
+            <span className="text-sm font-medium capitalize">{val.replace(/_/g, ' ')}</span>
+          </div>
+        ) : null)}
+      </div>
+    </div>
+  ) : null;
+
+  const notesBlock = scan.notes ? (
+    <div>
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Notes</p>
+      <div className="ios-section">
+        <div className="ios-row">
+          <p className="text-sm whitespace-pre-wrap">{scan.notes}</p>
+        </div>
+      </div>
+    </div>
+  ) : null;
+
   return (
     <main className="tab-content bg-background">
-      <div className="px-4 pt-safe pb-4 flex items-center gap-3">
-        <Link href="/measurements" className="text-primary p-1 -ml-1">
-          <ChevronLeft className="h-5 w-5" />
-        </Link>
-        <h1 className="text-2xl font-bold flex-1">InBody Scan</h1>
-        <button
-          onClick={onDelete}
-          className="text-rose-500 p-2 min-h-[44px] min-w-[44px] flex items-center justify-center"
-          aria-label="Delete scan"
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
-      </div>
-
-      <div className="px-4 pb-20 space-y-4">
-        {/* Header card */}
-        <div className="rounded-2xl bg-card border border-border p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <div className="text-sm text-muted-foreground">{scan.device}{scan.venue ? ` · ${scan.venue}` : ''}</div>
-              <div className="text-sm font-medium">{dateStr}</div>
-            </div>
-            {scan.inbody_score != null && (
-              <div className="text-right">
-                <div className="text-xs text-muted-foreground">Score</div>
-                <div className="text-2xl font-bold">{scan.inbody_score}</div>
-              </div>
-            )}
-          </div>
+      <div className="max-w-lg md:max-w-6xl mx-auto px-4 md:px-0">
+        <div className="pt-safe pb-4 flex items-center gap-3 md:px-4">
+          <Link href="/measurements" className="text-primary p-1 -ml-1">
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-2xl font-bold flex-1">InBody Scan</h1>
+          <button
+            onClick={onDelete}
+            className="text-rose-500 p-2 min-h-[44px] min-w-[44px] flex items-center justify-center"
+            aria-label="Delete scan"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
         </div>
 
-        {/* Reference selector */}
-        <div>
-          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Compare against</p>
-          <div className="flex rounded-xl bg-card border border-border p-1 gap-1">
-            {(['M', 'F', 'ME'] as const).map(r => (
-              <button
-                key={r}
-                onClick={() => setReference(r)}
-                className={`flex-1 py-2 text-sm font-medium rounded-lg transition-colors ${
-                  reference === r
-                    ? 'bg-primary text-white'
-                    : 'text-muted-foreground'
-                }`}
-              >
-                {r === 'M' ? 'Male' : r === 'F' ? 'Female' : 'Me'}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Metric groups */}
-        {GROUPS.map(group => {
-          const metrics = METRICS.filter(m => m.group === group);
-          const rows = metrics.map(m => {
-            const value = scanValue(scan, m.key as string);
-            const status = resolveStatus(value, m, reference, norms, goals);
-            return { m, value, status };
-          }).filter(r => r.value != null || r.status.label !== 'NO REF');
-
-          if (rows.length === 0) return null;
-
-          return (
-            <div key={group}>
-              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">
-                {GROUP_LABELS[group]}
-              </p>
-              <div className="ios-section">
-                {rows.map(({ m, value, status }) => {
-                  const cls = statusColorClasses(status.color);
-                  return (
-                    <div key={m.key as string} className="ios-row flex-wrap gap-2">
-                      <div className="flex-1 min-w-0">
-                        <div className="text-sm font-medium truncate">{m.label}</div>
-                        <div className="text-xs text-muted-foreground">
-                          {reference === 'ME' ? 'Goal' : 'Normal'}: {status.refText}
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <div className="text-sm font-semibold">{formatValue(value, m)}</div>
-                        <span
-                          className={`inline-block mt-0.5 px-1.5 py-0.5 text-[10px] font-bold rounded ring-1 ${cls.text} ${cls.bg} ${cls.ring}`}
-                        >
-                          {status.label}
-                        </span>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          );
-        })}
-
-        {/* Balance */}
-        {(scan.balance_upper || scan.balance_lower || scan.balance_upper_lower) && (
-          <div>
-            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Body Balance</p>
-            <div className="ios-section">
-              {([
-                ['Upper', scan.balance_upper],
-                ['Lower', scan.balance_lower],
-                ['Upper–Lower', scan.balance_upper_lower],
-              ] as const).map(([label, val]) => val ? (
-                <div key={label} className="ios-row justify-between">
-                  <span className="text-sm text-muted-foreground">{label}</span>
-                  <span className="text-sm font-medium capitalize">{val.replace(/_/g, ' ')}</span>
+        <div className="pb-20 grid grid-cols-1 md:grid-cols-4 gap-6 auto-rows-min">
+          {/* Left column: sticky summary (scan header + reference toggle + headline metrics)
+              NB: sticky lives on the OUTER wrapper — .ios-section has overflow-hidden which would clip it. */}
+          <div className="md:col-span-1 md:sticky md:top-4 self-start space-y-4">
+            {/* Header card */}
+            <div className="rounded-2xl bg-card border border-border p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm text-muted-foreground">{scan.device}{scan.venue ? ` · ${scan.venue}` : ''}</div>
+                  <div className="text-sm font-medium">{dateStr}</div>
                 </div>
-              ) : null)}
-            </div>
-          </div>
-        )}
-
-        {scan.notes && (
-          <div>
-            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Notes</p>
-            <div className="ios-section">
-              <div className="ios-row">
-                <p className="text-sm whitespace-pre-wrap">{scan.notes}</p>
+                {scan.inbody_score != null && (
+                  <div className="text-right">
+                    <div className="text-xs text-muted-foreground">Score</div>
+                    <div className="text-2xl font-bold">{scan.inbody_score}</div>
+                  </div>
+                )}
               </div>
             </div>
+
+            {/* Reference selector */}
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Compare against</p>
+              <div className="flex rounded-xl bg-card border border-border p-1 gap-1">
+                {(['M', 'F', 'ME'] as const).map(r => (
+                  <button
+                    key={r}
+                    onClick={() => setReference(r)}
+                    className={`flex-1 py-2 text-sm font-medium rounded-lg transition-colors ${
+                      reference === r
+                        ? 'bg-primary text-white'
+                        : 'text-muted-foreground'
+                    }`}
+                  >
+                    {r === 'M' ? 'Male' : r === 'F' ? 'Female' : 'Me'}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Headline metrics at a glance */}
+            <div className="ios-section">
+              {[
+                { label: 'Weight', val: scan.weight_kg, unit: 'kg' },
+                { label: 'PBF', val: scan.pbf_pct, unit: '%' },
+                { label: 'SMM', val: scan.smm_kg, unit: 'kg' },
+              ].filter(h => h.val != null).map(h => (
+                <div key={h.label} className="ios-row justify-between">
+                  <span className="text-sm text-muted-foreground">{h.label}</span>
+                  <span className="text-sm font-semibold">{h.val} {h.unit}</span>
+                </div>
+              ))}
+            </div>
           </div>
-        )}
+
+          {/* Right column: metric groups as a 2-col grid on md:+, 1-col on mobile.
+              auto-rows-min keeps cards intrinsic height so uneven groups don't inflate rows. */}
+          <div className="md:col-span-3 grid grid-cols-1 md:grid-cols-2 gap-4 auto-rows-min">
+            {GROUPS.map(group => {
+              const metrics = METRICS.filter(m => m.group === group);
+              const rows = metrics.map(m => {
+                const value = scanValue(scan, m.key as string);
+                const status = resolveStatus(value, m, reference, norms, goals);
+                return { m, value, status };
+              }).filter(r => r.value != null || r.status.label !== 'NO REF');
+
+              if (rows.length === 0) return null;
+
+              return (
+                <div key={group}>
+                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">
+                    {GROUP_LABELS[group]}
+                  </p>
+                  <div className="ios-section">
+                    {rows.map(({ m, value, status }) => {
+                      const cls = statusColorClasses(status.color);
+                      return (
+                        <div key={m.key as string} className="ios-row flex-wrap gap-2">
+                          <div className="flex-1 min-w-0">
+                            <div className="text-sm font-medium truncate">{m.label}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {reference === 'ME' ? 'Goal' : 'Normal'}: {status.refText}
+                            </div>
+                          </div>
+                          <div className="text-right">
+                            <div className="text-sm font-semibold">{formatValue(value, m)}</div>
+                            <span
+                              className={`inline-block mt-0.5 px-1.5 py-0.5 text-[10px] font-bold rounded ring-1 ${cls.text} ${cls.bg} ${cls.ring}`}
+                            >
+                              {status.label}
+                            </span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+
+            {balanceBlock}
+            {notesBlock}
+          </div>
+        </div>
       </div>
     </main>
   );

--- a/src/app/measurements/inbody/new/page.tsx
+++ b/src/app/measurements/inbody/new/page.tsx
@@ -74,16 +74,20 @@ export default function NewInbodyScanPage() {
     }
   }
 
+  // Metric keys that deserve pair-rendering on md:+ (matches plan: weight+height, PBF%+SMM%, visceral_fat+bmr_kcal)
+  const PAIRED_KEYS = new Set<string>(['weight_kg', 'height_cm', 'pbf_pct', 'smm_pct', 'visceral_fat_level', 'bmr_kcal']);
+
   return (
     <main className="tab-content bg-background">
-      <div className="px-4 pt-safe pb-4 flex items-center gap-3">
-        <Link href="/measurements" className="text-primary p-1 -ml-1">
-          <ChevronLeft className="h-5 w-5" />
-        </Link>
-        <h1 className="text-2xl font-bold">New InBody Scan</h1>
-      </div>
+      <div className="max-w-md md:max-w-2xl mx-auto">
+        <div className="px-4 pt-safe pb-4 flex items-center gap-3">
+          <Link href="/measurements" className="text-primary p-1 -ml-1">
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-2xl font-bold">New InBody Scan</h1>
+        </div>
 
-      <div className="px-4 pb-20 space-y-4">
+        <div className="px-4 pb-20 space-y-4">
         {/* Meta */}
         <div>
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Meta</p>
@@ -136,22 +140,32 @@ export default function NewInbodyScanPage() {
                 {GROUP_LABELS[group]}
               </p>
               <div className="ios-section">
-                {metrics.map(m => (
-                  <div key={m.key as string} className="ios-row justify-between gap-3">
-                    <label className="text-sm text-muted-foreground flex-1" htmlFor={`f-${m.key as string}`}>
-                      {m.label}{m.unit ? ` (${m.unit})` : ''}
-                    </label>
-                    <input
-                      id={`f-${m.key as string}`}
-                      type="number"
-                      inputMode="decimal"
-                      step="any"
-                      value={values[m.key as string] ?? ''}
-                      onChange={e => setValue(m.key as string, e.target.value)}
-                      className="w-28 bg-transparent text-sm text-right outline-none min-h-[44px]"
-                    />
-                  </div>
-                ))}
+                <div className="grid grid-cols-1 md:grid-cols-2 md:gap-x-4">
+                  {metrics.map(m => {
+                    const k = m.key as string;
+                    // Most rows stay full-width; only the "paired" set sits side-by-side at md:+
+                    const paired = PAIRED_KEYS.has(k);
+                    return (
+                      <div
+                        key={k}
+                        className={`ios-row justify-between gap-3 ${paired ? '' : 'md:col-span-2'}`}
+                      >
+                        <label className="text-sm text-muted-foreground flex-1" htmlFor={`f-${k}`}>
+                          {m.label}{m.unit ? ` (${m.unit})` : ''}
+                        </label>
+                        <input
+                          id={`f-${k}`}
+                          type="number"
+                          inputMode="decimal"
+                          step="any"
+                          value={values[k] ?? ''}
+                          onChange={e => setValue(k, e.target.value)}
+                          className="w-28 bg-transparent text-sm text-right outline-none min-h-[44px]"
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             </div>
           );
@@ -217,15 +231,16 @@ export default function NewInbodyScanPage() {
 
         {error && <p className="text-sm text-rose-500 px-1">{error}</p>}
 
-        {/* Submit */}
-        <div className="flex justify-end">
+        {/* Submit — full-width on mobile, auto-right on md:+ */}
+        <div className="flex md:justify-end">
           <button
             onClick={submit}
             disabled={saving}
-            className="px-6 py-3 bg-primary text-white text-sm font-semibold rounded-lg disabled:opacity-40"
+            className="w-full md:w-auto md:px-8 md:ml-auto px-6 py-3 bg-primary text-white text-sm font-semibold rounded-lg disabled:opacity-40"
           >
             {saving ? 'Saving…' : 'Save Scan'}
           </button>
+        </div>
         </div>
       </div>
     </main>

--- a/src/app/measurements/measurements.test.ts
+++ b/src/app/measurements/measurements.test.ts
@@ -133,6 +133,35 @@ describe('toDateInputValue', () => {
   });
 });
 
+// ===== URL-driven activeTab initialization =====
+// Mirrors the derivation logic inside MeasurementsInner:
+//   const initialTab = (searchParams?.get('tab') as TabKey | null) ?? 'measurements';
+// We test the derivation directly rather than rendering the component (which
+// would require a full next/navigation mock harness).
+
+type TabKey = 'measurements' | 'photos' | 'inbody';
+
+function deriveInitialTab(searchParamsGet: (k: string) => string | null): TabKey {
+  return (searchParamsGet('tab') as TabKey | null) ?? 'measurements';
+}
+
+describe('measurements activeTab initialization', () => {
+  it('defaults to "measurements" when no tab param is in the URL', () => {
+    const get = (_k: string) => null;
+    expect(deriveInitialTab(get)).toBe('measurements');
+  });
+
+  it('initializes to "inbody" when ?tab=inbody is in the URL', () => {
+    const get = (k: string) => k === 'tab' ? 'inbody' : null;
+    expect(deriveInitialTab(get)).toBe('inbody');
+  });
+
+  it('initializes to "photos" when ?tab=photos is in the URL', () => {
+    const get = (k: string) => k === 'tab' ? 'photos' : null;
+    expect(deriveInitialTab(get)).toBe('photos');
+  });
+});
+
 // ===== chart data derivation logic =====
 
 describe('chart data derivation', () => {

--- a/src/app/measurements/page.tsx
+++ b/src/app/measurements/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { Suspense, useEffect, useState, useRef } from 'react';
 import { ChevronLeft, Trash2, Camera, ImageIcon, Activity, Target, Plus } from 'lucide-react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
 import { useUnit } from '@/context/UnitContext';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+  ReferenceLine, Legend,
 } from 'recharts';
-import type { MeasurementLog, ProgressPhoto, InbodyScan } from '@/types';
+import type { MeasurementLog, ProgressPhoto, InbodyScan, BodyGoal } from '@/types';
 import { apiBase } from '@/lib/api/client';
 
 const SITES = [
@@ -18,6 +21,19 @@ const SITES = [
 ] as const;
 
 type SiteKey = typeof SITES[number]['key'];
+type TabKey = 'measurements' | 'photos' | 'inbody';
+
+// Distinct Tailwind-equivalent colors for multi-site overlay (no --chart-N tokens in globals.css)
+const SITE_COLORS: Record<SiteKey, string> = {
+  waist:     '#3b82f6', // blue-500
+  hips:      '#10b981', // emerald-500
+  thigh:     '#f97316', // orange-500
+  upper_arm: '#a855f7', // purple-500
+};
+
+// InBody metric key used for trend chart reference lines.
+// PBF% is the headline metric most users track; reference-line enrichment targets it.
+const INBODY_TREND_METRIC: keyof InbodyScan = 'pbf_pct';
 
 function apiHeaders(): HeadersInit {
   const key = process.env.NEXT_PUBLIC_REBIRTH_API_KEY;
@@ -53,9 +69,11 @@ const POSE_GUIDANCE: Record<string, string> = {
   back:  'Back to the camera, arms slightly away from your body, feet hip-width apart.',
 };
 
-export default function MeasurementsPage() {
+function MeasurementsInner() {
   const { fromInput, label } = useUnit();
-  const [activeTab, setActiveTab] = useState<'measurements' | 'photos' | 'inbody'>('measurements');
+  const searchParams = useSearchParams();
+  const initialTab = (searchParams?.get('tab') as TabKey | null) ?? 'measurements';
+  const [activeTab, setActiveTab] = useState<TabKey>(initialTab);
   const [inbodyScans, setInbodyScans] = useState<InbodyScan[]>([]);
   const [inbodyLoading, setInbodyLoading] = useState(true);
 
@@ -75,6 +93,16 @@ export default function MeasurementsPage() {
   const [photoNote, setPhotoNote] = useState('');
   const [uploading, setUploading] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
+
+  // Active goal for the selected trend metric (InBody trend enrichment)
+  const { data: inbodyGoal } = useQuery<BodyGoal | null>({
+    queryKey: ['body-goal', INBODY_TREND_METRIC],
+    queryFn: async () => {
+      const r = await fetch(`${apiBase()}/api/body-goals/${INBODY_TREND_METRIC}`, { headers: apiHeaders() });
+      if (!r.ok) return null;
+      return r.json() as Promise<BodyGoal>;
+    },
+  });
 
   useEffect(() => {
     fetch(`${apiBase()}/api/measurements?limit=90`, { headers: apiHeaders() })
@@ -187,7 +215,7 @@ export default function MeasurementsPage() {
     setPhotos(prev => prev.filter(p => p.uuid !== uuid));
   };
 
-  // Chart data: last 30 entries for the selected site, oldest first
+  // Single-site chart data (mobile + iPad portrait)
   const chartData = logs
     .filter(l => l.site === chartSite)
     .slice(0, 30)
@@ -196,6 +224,21 @@ export default function MeasurementsPage() {
       date: formatChartDate(l.measured_at),
       value: parseFloat(String(l.value_cm)),
     }));
+
+  // Multi-site chart data (lg:+) — one row per measured_at, with all 4 sites as keys
+  const multiSiteChartData = (() => {
+    const byDate = new Map<string, { date: string } & Partial<Record<SiteKey, number>>>();
+    // walk logs oldest-to-newest so Map retains chronological insertion order
+    for (const log of [...logs].reverse()) {
+      const s = log.site as SiteKey;
+      if (!SITES.find(si => si.key === s)) continue;
+      const dateKey = formatChartDate(log.measured_at);
+      const existing = byDate.get(dateKey) ?? { date: dateKey };
+      existing[s] = parseFloat(String(log.value_cm));
+      byDate.set(dateKey, existing);
+    }
+    return Array.from(byDate.values()).slice(-30);
+  })();
 
   // Most recent value per site (for snapshot row)
   const latestBySite: Partial<Record<SiteKey, MeasurementLog>> = {};
@@ -208,395 +251,590 @@ export default function MeasurementsPage() {
 
   const hasInput = SITES.some(s => inputs[s.key]) || !!weightInput;
 
-  return (
-    <main className="tab-content bg-background">
-      <div className="px-4 pt-safe pb-4 flex items-center gap-3">
-        <Link href="/settings" className="text-primary p-1 -ml-1">
-          <ChevronLeft className="h-5 w-5" />
-        </Link>
-        <h1 className="text-2xl font-bold">Measurements</h1>
+  // InBody trend chart — uses PBF% by default, most recent scans oldest-first
+  const inbodyTrendData = inbodyScans
+    .filter(s => s[INBODY_TREND_METRIC] != null)
+    .slice(0, 30)
+    .reverse()
+    .map(s => ({
+      date: formatChartDate(s.scanned_at),
+      value: typeof s[INBODY_TREND_METRIC] === 'number' ? (s[INBODY_TREND_METRIC] as number) : null,
+    }))
+    .filter(p => p.value != null);
+
+  const previousScanValue = (() => {
+    if (inbodyScans.length < 2) return null;
+    const v = inbodyScans[1]?.[INBODY_TREND_METRIC];
+    return typeof v === 'number' ? v : null;
+  })();
+
+  const goalValue = typeof inbodyGoal?.target_value === 'number' ? inbodyGoal.target_value : null;
+
+  // ── Section renderers (extracted so CSS-only show/hide at md:+ is trivial) ──
+
+  const measurementsSection = (
+    <div className="space-y-4">
+      {/* Current snapshot */}
+      {(Object.keys(latestBySite).length > 0) && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Current</p>
+          <div className="ios-section">
+            <div className="ios-row flex-wrap gap-x-6 gap-y-2 py-2">
+              {SITES.filter(s => latestBySite[s.key]).map(s => (
+                <div key={s.key} className="flex flex-col">
+                  <span className="text-xs text-muted-foreground">{s.label}</span>
+                  <span className="text-sm font-medium">{latestBySite[s.key]!.value_cm} cm</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Log new entry */}
+      <div>
+        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Log Entry</p>
+        <div className="ios-section">
+          <div className="ios-row justify-between">
+            <span className="text-sm text-muted-foreground">Date</span>
+            <input
+              type="date"
+              value={date}
+              onChange={e => setDate(e.target.value)}
+              className="bg-transparent text-sm text-right outline-none min-h-[44px] text-muted-foreground"
+            />
+          </div>
+          <div className="ios-row flex-wrap gap-3">
+            {SITES.map(s => (
+              <input
+                key={s.key}
+                type="number"
+                inputMode="decimal"
+                placeholder={`${s.label} (cm)`}
+                value={inputs[s.key] ?? ''}
+                onChange={e => setInputs(prev => ({ ...prev, [s.key]: e.target.value }))}
+                className="flex-1 min-w-[110px] bg-transparent text-sm outline-none min-h-[44px]"
+              />
+            ))}
+          </div>
+          <div className="ios-row">
+            <input
+              type="number"
+              inputMode="decimal"
+              placeholder={`Weight (${label})`}
+              value={weightInput}
+              onChange={e => setWeightInput(e.target.value)}
+              className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
+            />
+          </div>
+          <div className="ios-row justify-end">
+            <button
+              onClick={handleSaveMeasurements}
+              disabled={saving || !hasInput}
+              className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
       </div>
 
-      {/* Tab switcher */}
-      <div className="flex border-b border-border mx-4 mb-4">
-        {(['measurements', 'photos', 'inbody'] as const).map(tab => (
-          <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className={`flex-1 py-2 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === tab
-                ? 'border-primary text-primary'
-                : 'border-transparent text-muted-foreground'
-            }`}
-          >
-            {tab === 'measurements' ? 'Measurements' : tab === 'photos' ? 'Photos' : 'InBody'}
-          </button>
-        ))}
-      </div>
-
-      <div className="px-4 pb-8 space-y-4">
-
-        {activeTab === 'measurements' && (
-          <>
-            {/* Current snapshot */}
-            {(Object.keys(latestBySite).length > 0) && (
-              <div>
-                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Current</p>
-                <div className="ios-section">
-                  <div className="ios-row flex-wrap gap-x-6 gap-y-2 py-2">
-                    {SITES.filter(s => latestBySite[s.key]).map(s => (
-                      <div key={s.key} className="flex flex-col">
-                        <span className="text-xs text-muted-foreground">{s.label}</span>
-                        <span className="text-sm font-medium">{latestBySite[s.key]!.value_cm} cm</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Log new entry */}
-            <div>
-              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Log Entry</p>
-              <div className="ios-section">
-                <div className="ios-row justify-between">
-                  <span className="text-sm text-muted-foreground">Date</span>
-                  <input
-                    type="date"
-                    value={date}
-                    onChange={e => setDate(e.target.value)}
-                    className="bg-transparent text-sm text-right outline-none min-h-[44px] text-muted-foreground"
-                  />
-                </div>
-                <div className="ios-row flex-wrap gap-3">
-                  {SITES.map(s => (
-                    <input
-                      key={s.key}
-                      type="number"
-                      inputMode="decimal"
-                      placeholder={`${s.label} (cm)`}
-                      value={inputs[s.key] ?? ''}
-                      onChange={e => setInputs(prev => ({ ...prev, [s.key]: e.target.value }))}
-                      className="flex-1 min-w-[110px] bg-transparent text-sm outline-none min-h-[44px]"
-                    />
-                  ))}
-                </div>
-                <div className="ios-row">
-                  <input
-                    type="number"
-                    inputMode="decimal"
-                    placeholder={`Weight (${label})`}
-                    value={weightInput}
-                    onChange={e => setWeightInput(e.target.value)}
-                    className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
-                  />
-                </div>
-                <div className="ios-row justify-end">
-                  <button
-                    onClick={handleSaveMeasurements}
-                    disabled={saving || !hasInput}
-                    className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
-                  >
-                    {saving ? 'Saving…' : 'Save'}
-                  </button>
-                </div>
-              </div>
+      {/* Trend chart */}
+      {!loading && logs.length > 1 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Trend</p>
+          <div className="ios-section">
+            {/* Single-site selector — hidden at lg:+ (multi-site overlay takes over) */}
+            <div className="ios-row flex-wrap gap-2 py-1 lg:hidden">
+              {SITES.map(s => (
+                <button
+                  key={s.key}
+                  onClick={() => setChartSite(s.key)}
+                  className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                    chartSite === s.key
+                      ? 'bg-primary text-white border-primary'
+                      : 'border-border text-muted-foreground'
+                  }`}
+                >
+                  {s.label}
+                </button>
+              ))}
             </div>
 
-            {/* Trend chart */}
-            {!loading && logs.length > 1 && (
-              <div>
-                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Trend</p>
-                <div className="ios-section">
-                  <div className="ios-row flex-wrap gap-2 py-1">
-                    {SITES.map(s => (
-                      <button
-                        key={s.key}
-                        onClick={() => setChartSite(s.key)}
-                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                          chartSite === s.key
-                            ? 'bg-primary text-white border-primary'
-                            : 'border-border text-muted-foreground'
-                        }`}
-                      >
-                        {s.label}
-                      </button>
-                    ))}
+            {/* Mobile + iPad portrait: single-site line chart */}
+            <div className="lg:hidden">
+              {chartData.length > 1 ? (
+                <div className="px-1 py-2">
+                  <div className="h-[200px] md:h-[320px]">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: -20 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                        <XAxis
+                          dataKey="date"
+                          tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                          tickLine={false}
+                          axisLine={false}
+                          interval="preserveStartEnd"
+                        />
+                        <YAxis
+                          tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                          tickLine={false}
+                          axisLine={false}
+                          domain={['auto', 'auto']}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: 'hsl(var(--card))',
+                            border: '1px solid hsl(var(--border))',
+                            borderRadius: '8px',
+                            fontSize: 12,
+                          }}
+                          formatter={(v) => [`${v} cm`, SITES.find(s => s.key === chartSite)?.label ?? chartSite]}
+                        />
+                        <Line
+                          type="monotone"
+                          dataKey="value"
+                          stroke="hsl(var(--primary))"
+                          strokeWidth={2}
+                          dot={chartData.length <= 10}
+                          activeDot={{ r: 4 }}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
                   </div>
-                  {chartData.length > 1 ? (
-                    <div className="px-1 py-2">
-                      <ResponsiveContainer width="100%" height={160}>
-                        <LineChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: -20 }}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                          <XAxis
-                            dataKey="date"
-                            tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
-                            tickLine={false}
-                            axisLine={false}
-                            interval="preserveStartEnd"
-                          />
-                          <YAxis
-                            tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
-                            tickLine={false}
-                            axisLine={false}
-                            domain={['auto', 'auto']}
-                          />
-                          <Tooltip
-                            contentStyle={{
-                              backgroundColor: 'hsl(var(--card))',
-                              border: '1px solid hsl(var(--border))',
-                              borderRadius: '8px',
-                              fontSize: 12,
-                            }}
-                            formatter={(v) => [`${v} cm`, SITES.find(s => s.key === chartSite)?.label ?? chartSite]}
-                          />
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground px-2 pb-3">
+                  Log at least 2 entries for {SITES.find(s => s.key === chartSite)?.label.toLowerCase()} to see a trend.
+                </p>
+              )}
+            </div>
+
+            {/* Desktop / iPad landscape (lg:+): 4-site overlay with legend */}
+            <div className="hidden lg:block">
+              {multiSiteChartData.length > 1 ? (
+                <div className="px-1 py-2">
+                  <div className="h-[360px]">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={multiSiteChartData} margin={{ top: 4, right: 8, bottom: 0, left: -20 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                        <XAxis
+                          dataKey="date"
+                          tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                          tickLine={false}
+                          axisLine={false}
+                          interval="preserveStartEnd"
+                        />
+                        <YAxis
+                          tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                          tickLine={false}
+                          axisLine={false}
+                          domain={['auto', 'auto']}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: 'hsl(var(--card))',
+                            border: '1px solid hsl(var(--border))',
+                            borderRadius: '8px',
+                            fontSize: 12,
+                          }}
+                        />
+                        <Legend verticalAlign="top" align="right" iconSize={10} wrapperStyle={{ fontSize: '12px' }} />
+                        {SITES.map(s => (
                           <Line
+                            key={s.key}
                             type="monotone"
-                            dataKey="value"
-                            stroke="hsl(var(--primary))"
+                            dataKey={s.key}
+                            name={s.label}
+                            stroke={SITE_COLORS[s.key]}
                             strokeWidth={2}
-                            dot={chartData.length <= 10}
+                            dot={false}
                             activeDot={{ r: 4 }}
+                            connectNulls
                           />
-                        </LineChart>
-                      </ResponsiveContainer>
+                        ))}
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground px-2 pb-3">
+                  Log entries across multiple sites to see the overlay.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* History */}
+      {!loading && logs.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">History</p>
+          <div className="ios-section">
+            {logs.slice(0, 30).map((log, i) => (
+              <div
+                key={log.uuid}
+                className={`ios-row justify-between ${i < Math.min(logs.length, 30) - 1 ? 'border-b border-border' : ''}`}
+              >
+                <div className="flex-1 min-w-0">
+                  <span className="text-sm font-medium">
+                    {SITES.find(s => s.key === log.site)?.label ?? log.site}
+                  </span>
+                  <span className="text-sm text-muted-foreground ml-2">{log.value_cm} cm</span>
+                </div>
+                <span className="text-xs text-muted-foreground mr-3">
+                  {formatDate(log.measured_at)}
+                </span>
+                <button
+                  onClick={() => handleDeleteMeasurement(log.uuid)}
+                  className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!loading && logs.length === 0 && (
+        <p className="text-xs text-muted-foreground px-1">No measurements logged yet.</p>
+      )}
+    </div>
+  );
+
+  const photosSection = (
+    <div className="space-y-4">
+      {/* Upload */}
+      <div>
+        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Add Photo</p>
+        <div className="ios-section">
+          {/* Pose selector */}
+          <div className="ios-row gap-2">
+            {(['front', 'side', 'back'] as const).map(pose => (
+              <button
+                key={pose}
+                onClick={() => setSelectedPose(pose)}
+                className={`flex-1 py-2 text-sm font-medium rounded-lg border capitalize transition-colors ${
+                  selectedPose === pose
+                    ? 'bg-primary text-white border-primary'
+                    : 'border-border text-muted-foreground'
+                }`}
+              >
+                {pose}
+              </button>
+            ))}
+          </div>
+
+          {/* Pose guidance */}
+          <div className="ios-row py-1">
+            <p className="text-xs text-muted-foreground">{POSE_GUIDANCE[selectedPose]}</p>
+          </div>
+
+          {/* Note */}
+          <div className="ios-row">
+            <input
+              type="text"
+              placeholder="Note (optional)"
+              value={photoNote}
+              onChange={e => setPhotoNote(e.target.value)}
+              className="flex-1 bg-transparent text-sm outline-none min-h-[44px] text-muted-foreground"
+            />
+          </div>
+
+          <div className="ios-row justify-end">
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={e => {
+                const file = e.target.files?.[0];
+                if (file) handlePhotoUpload(file);
+                e.target.value = '';
+              }}
+            />
+            <button
+              onClick={() => fileRef.current?.click()}
+              disabled={uploading}
+              className="flex items-center gap-2 px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
+            >
+              <Camera className="h-4 w-4" />
+              {uploading ? 'Uploading…' : 'Choose Photo'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Gallery */}
+      {!photosLoading && photos.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Gallery</p>
+          <div className="space-y-3">
+            {photos.map(photo => (
+              <div key={photo.uuid} className="ios-section overflow-hidden">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={photo.blob_url}
+                  alt={`${photo.pose} progress photo`}
+                  className="w-full object-cover max-h-[420px] rounded-t-xl"
+                />
+                <div className="ios-row justify-between">
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium capitalize">{photo.pose}</span>
+                    {photo.notes && (
+                      <span className="text-xs text-muted-foreground">{photo.notes}</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground">{formatDate(photo.taken_at)}</span>
+                    <button
+                      onClick={() => handleDeletePhoto(photo.uuid)}
+                      className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!photosLoading && photos.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <ImageIcon className="h-12 w-12 md:h-16 md:w-16 mb-3 opacity-20" />
+          <p className="text-sm">No progress photos yet.</p>
+          <p className="text-xs mt-1">Upload your first photo above.</p>
+        </div>
+      )}
+    </div>
+  );
+
+  const inbodySection = (
+    <div className="space-y-4">
+      {/* Action row */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <Link
+          href="/measurements/inbody/new"
+          className="flex items-center gap-2 px-3 py-2 bg-primary text-white text-sm font-medium rounded-lg"
+        >
+          <Plus className="h-4 w-4" />
+          New Scan
+        </Link>
+        {inbodyScans.length >= 2 && (
+          <Link
+            href="/measurements/inbody/compare"
+            className="flex items-center gap-2 px-3 py-2 border border-border text-sm font-medium rounded-lg"
+          >
+            Compare
+          </Link>
+        )}
+        <Link
+          href="/measurements/goals"
+          className="flex items-center gap-2 px-3 py-2 border border-border text-sm font-medium rounded-lg"
+        >
+          <Target className="h-4 w-4" />
+          Goals
+        </Link>
+      </div>
+
+      {inbodyLoading && <p className="text-xs text-muted-foreground px-1">Loading scans…</p>}
+
+      {!inbodyLoading && inbodyScans.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <Activity className="h-12 w-12 md:h-16 md:w-16 mb-3 opacity-20" />
+          <p className="text-sm">No InBody scans yet.</p>
+          <p className="text-xs mt-1">Hand-enter your first scan from the sheet.</p>
+        </div>
+      )}
+
+      {/* Trend chart — PBF% with goal + previous-scan reference lines */}
+      {!inbodyLoading && inbodyTrendData.length > 1 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">PBF% Trend</p>
+          <div className="ios-section">
+            <div className="px-1 py-2">
+              <div className="h-[200px] md:h-[320px] lg:h-[360px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={inbodyTrendData} margin={{ top: 4, right: 24, bottom: 0, left: -20 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                      tickLine={false}
+                      axisLine={false}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                      tickLine={false}
+                      axisLine={false}
+                      domain={['auto', 'auto']}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: 'hsl(var(--card))',
+                        border: '1px solid hsl(var(--border))',
+                        borderRadius: '8px',
+                        fontSize: 12,
+                      }}
+                      formatter={(v) => [`${v}%`, 'PBF']}
+                    />
+                    {goalValue != null && (
+                      <ReferenceLine
+                        y={goalValue}
+                        stroke="currentColor"
+                        strokeDasharray="4 4"
+                        opacity={0.5}
+                        label={{ value: 'Goal', position: 'right', fill: 'currentColor', fontSize: 10 }}
+                      />
+                    )}
+                    {previousScanValue != null && (
+                      <ReferenceLine
+                        y={previousScanValue}
+                        stroke="currentColor"
+                        strokeDasharray="2 6"
+                        opacity={0.4}
+                        label={{ value: 'Prev', position: 'right', fill: 'currentColor', fontSize: 10 }}
+                      />
+                    )}
+                    <Line
+                      type="monotone"
+                      dataKey="value"
+                      stroke="hsl(var(--primary))"
+                      strokeWidth={2}
+                      dot={inbodyTrendData.length <= 10}
+                      activeDot={{ r: 4 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!inbodyLoading && inbodyScans.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Scans</p>
+          <div className="space-y-2">
+            {inbodyScans.map(scan => (
+              <Link
+                key={scan.uuid}
+                href={`/measurements/inbody/detail?uuid=${scan.uuid}`}
+                className="block rounded-2xl bg-card border border-border p-4 active:scale-[0.99] transition"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-sm font-semibold">{formatDate(scan.scanned_at)}</div>
+                    <div className="text-xs text-muted-foreground">{scan.device}{scan.venue ? ` · ${scan.venue}` : ''}</div>
+                  </div>
+                  {scan.inbody_score != null && (
+                    <div className="text-right">
+                      <div className="text-xs text-muted-foreground">Score</div>
+                      <div className="text-lg font-bold">{scan.inbody_score}</div>
                     </div>
-                  ) : (
-                    <p className="text-xs text-muted-foreground px-2 pb-3">Log at least 2 entries for {SITES.find(s => s.key === chartSite)?.label.toLowerCase()} to see a trend.</p>
                   )}
                 </div>
-              </div>
-            )}
-
-            {/* History */}
-            {!loading && logs.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">History</p>
-                <div className="ios-section">
-                  {logs.slice(0, 30).map((log, i) => (
-                    <div
-                      key={log.uuid}
-                      className={`ios-row justify-between ${i < Math.min(logs.length, 30) - 1 ? 'border-b border-border' : ''}`}
-                    >
-                      <div className="flex-1 min-w-0">
-                        <span className="text-sm font-medium">
-                          {SITES.find(s => s.key === log.site)?.label ?? log.site}
-                        </span>
-                        <span className="text-sm text-muted-foreground ml-2">{log.value_cm} cm</span>
-                      </div>
-                      <span className="text-xs text-muted-foreground mr-3">
-                        {formatDate(log.measured_at)}
-                      </span>
-                      <button
-                        onClick={() => handleDeleteMeasurement(log.uuid)}
-                        className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  ))}
+                <div className="flex flex-wrap gap-x-4 gap-y-1 mt-3 text-xs">
+                  {scan.weight_kg != null && (
+                    <div><span className="text-muted-foreground">Weight </span><span className="font-medium">{scan.weight_kg} kg</span></div>
+                  )}
+                  {scan.pbf_pct != null && (
+                    <div><span className="text-muted-foreground">PBF </span><span className="font-medium">{scan.pbf_pct}%</span></div>
+                  )}
+                  {scan.smm_kg != null && (
+                    <div><span className="text-muted-foreground">SMM </span><span className="font-medium">{scan.smm_kg} kg</span></div>
+                  )}
+                  {scan.visceral_fat_level != null && (
+                    <div><span className="text-muted-foreground">VFL </span><span className="font-medium">{scan.visceral_fat_level}</span></div>
+                  )}
                 </div>
-              </div>
-            )}
-
-            {!loading && logs.length === 0 && (
-              <p className="text-xs text-muted-foreground px-1">No measurements logged yet.</p>
-            )}
-          </>
-        )}
-
-        {activeTab === 'photos' && (
-          <>
-            {/* Upload */}
-            <div>
-              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Add Photo</p>
-              <div className="ios-section">
-                {/* Pose selector */}
-                <div className="ios-row gap-2">
-                  {(['front', 'side', 'back'] as const).map(pose => (
-                    <button
-                      key={pose}
-                      onClick={() => setSelectedPose(pose)}
-                      className={`flex-1 py-2 text-sm font-medium rounded-lg border capitalize transition-colors ${
-                        selectedPose === pose
-                          ? 'bg-primary text-white border-primary'
-                          : 'border-border text-muted-foreground'
-                      }`}
-                    >
-                      {pose}
-                    </button>
-                  ))}
-                </div>
-
-                {/* Pose guidance */}
-                <div className="ios-row py-1">
-                  <p className="text-xs text-muted-foreground">{POSE_GUIDANCE[selectedPose]}</p>
-                </div>
-
-                {/* Note */}
-                <div className="ios-row">
-                  <input
-                    type="text"
-                    placeholder="Note (optional)"
-                    value={photoNote}
-                    onChange={e => setPhotoNote(e.target.value)}
-                    className="flex-1 bg-transparent text-sm outline-none min-h-[44px] text-muted-foreground"
-                  />
-                </div>
-
-                <div className="ios-row justify-end">
-                  <input
-                    ref={fileRef}
-                    type="file"
-                    accept="image/*"
-                    className="hidden"
-                    onChange={e => {
-                      const file = e.target.files?.[0];
-                      if (file) handlePhotoUpload(file);
-                      e.target.value = '';
-                    }}
-                  />
-                  <button
-                    onClick={() => fileRef.current?.click()}
-                    disabled={uploading}
-                    className="flex items-center gap-2 px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
-                  >
-                    <Camera className="h-4 w-4" />
-                    {uploading ? 'Uploading…' : 'Choose Photo'}
-                  </button>
-                </div>
-              </div>
-            </div>
-
-            {/* Gallery */}
-            {!photosLoading && photos.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Gallery</p>
-                <div className="space-y-3">
-                  {photos.map(photo => (
-                    <div key={photo.uuid} className="ios-section overflow-hidden">
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={photo.blob_url}
-                        alt={`${photo.pose} progress photo`}
-                        className="w-full object-cover max-h-[420px] rounded-t-xl"
-                      />
-                      <div className="ios-row justify-between">
-                        <div className="flex flex-col">
-                          <span className="text-sm font-medium capitalize">{photo.pose}</span>
-                          {photo.notes && (
-                            <span className="text-xs text-muted-foreground">{photo.notes}</span>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="text-xs text-muted-foreground">{formatDate(photo.taken_at)}</span>
-                          <button
-                            onClick={() => handleDeletePhoto(photo.uuid)}
-                            className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {!photosLoading && photos.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-                <ImageIcon className="h-12 w-12 mb-3 opacity-20" />
-                <p className="text-sm">No progress photos yet.</p>
-                <p className="text-xs mt-1">Upload your first photo above.</p>
-              </div>
-            )}
-          </>
-        )}
-
-        {activeTab === 'inbody' && (
-          <>
-            {/* Action row */}
-            <div className="flex items-center gap-2">
-              <Link
-                href="/measurements/inbody/new"
-                className="flex items-center gap-2 px-3 py-2 bg-primary text-white text-sm font-medium rounded-lg"
-              >
-                <Plus className="h-4 w-4" />
-                New Scan
               </Link>
-              {inbodyScans.length >= 2 && (
-                <Link
-                  href="/measurements/inbody/compare"
-                  className="flex items-center gap-2 px-3 py-2 border border-border text-sm font-medium rounded-lg"
-                >
-                  Compare
-                </Link>
-              )}
-              <Link
-                href="/measurements/goals"
-                className="flex items-center gap-2 px-3 py-2 border border-border text-sm font-medium rounded-lg"
-              >
-                <Target className="h-4 w-4" />
-                Goals
-              </Link>
-            </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 
-            {inbodyLoading && <p className="text-xs text-muted-foreground px-1">Loading scans…</p>}
+  return (
+    <main className="tab-content bg-background">
+      <div className="max-w-lg md:max-w-5xl mx-auto">
+        <div className="px-4 pt-safe pb-4 flex items-center gap-3">
+          <Link href="/settings" className="text-primary p-1 -ml-1">
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-2xl font-bold">Measurements</h1>
+        </div>
 
-            {!inbodyLoading && inbodyScans.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-                <Activity className="h-12 w-12 mb-3 opacity-20" />
-                <p className="text-sm">No InBody scans yet.</p>
-                <p className="text-xs mt-1">Hand-enter your first scan from the sheet.</p>
-              </div>
-            )}
+        {/* Mobile tab switcher — hidden at md:+ (grid renders all three sections) */}
+        <div className="flex border-b border-border mx-4 mb-4 md:hidden">
+          {(['measurements', 'photos', 'inbody'] as const).map(tab => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 py-2 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === tab
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground'
+              }`}
+            >
+              {tab === 'measurements' ? 'Measurements' : tab === 'photos' ? 'Photos' : 'InBody'}
+            </button>
+          ))}
+        </div>
 
-            {!inbodyLoading && inbodyScans.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Scans</p>
-                <div className="space-y-2">
-                  {inbodyScans.map(scan => (
-                    <Link
-                      key={scan.uuid}
-                      href={`/measurements/inbody/detail?uuid=${scan.uuid}`}
-                      className="block rounded-2xl bg-card border border-border p-4 active:scale-[0.99] transition"
-                    >
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <div className="text-sm font-semibold">{formatDate(scan.scanned_at)}</div>
-                          <div className="text-xs text-muted-foreground">{scan.device}{scan.venue ? ` · ${scan.venue}` : ''}</div>
-                        </div>
-                        {scan.inbody_score != null && (
-                          <div className="text-right">
-                            <div className="text-xs text-muted-foreground">Score</div>
-                            <div className="text-lg font-bold">{scan.inbody_score}</div>
-                          </div>
-                        )}
-                      </div>
-                      <div className="flex flex-wrap gap-x-4 gap-y-1 mt-3 text-xs">
-                        {scan.weight_kg != null && (
-                          <div><span className="text-muted-foreground">Weight </span><span className="font-medium">{scan.weight_kg} kg</span></div>
-                        )}
-                        {scan.pbf_pct != null && (
-                          <div><span className="text-muted-foreground">PBF </span><span className="font-medium">{scan.pbf_pct}%</span></div>
-                        )}
-                        {scan.smm_kg != null && (
-                          <div><span className="text-muted-foreground">SMM </span><span className="font-medium">{scan.smm_kg} kg</span></div>
-                        )}
-                        {scan.visceral_fat_level != null && (
-                          <div><span className="text-muted-foreground">VFL </span><span className="font-medium">{scan.visceral_fat_level}</span></div>
-                        )}
-                      </div>
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            )}
-          </>
-        )}
+        {/* Content grid:
+            - mobile: single column, section visibility driven by activeTab
+            - md:+    3-column grid, all three sections visible side-by-side
+                     layout hierarchy (D1): InBody left (col-span-2), Measurements+Photos stacked right (col-span-1)
+        */}
+        <div className="px-4 pb-8 grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 auto-rows-min">
+          {/* InBody — primary pane on iPad (md:col-span-2), hidden on mobile unless tab active */}
+          <section
+            className={`${activeTab === 'inbody' ? 'block' : 'hidden'} md:block md:col-span-2 md:row-span-2`}
+          >
+            {inbodySection}
+          </section>
 
+          {/* Measurements — right rail top */}
+          <section
+            className={`${activeTab === 'measurements' ? 'block' : 'hidden'} md:block md:col-span-1`}
+          >
+            {measurementsSection}
+          </section>
+
+          {/* Photos — right rail bottom */}
+          <section
+            className={`${activeTab === 'photos' ? 'block' : 'hidden'} md:block md:col-span-1`}
+          >
+            {photosSection}
+          </section>
+        </div>
       </div>
     </main>
+  );
+}
+
+export default function MeasurementsPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="tab-content bg-background">
+          <div className="max-w-lg md:max-w-5xl mx-auto">
+            <div className="px-4 pt-safe pb-4 flex items-center gap-3">
+              <h1 className="text-2xl font-bold">Measurements</h1>
+            </div>
+            <p className="px-4 text-sm text-muted-foreground">Loading…</p>
+          </div>
+        </main>
+      }
+    >
+      <MeasurementsInner />
+    </Suspense>
   );
 }

--- a/src/components/InspoCaptureButton.tsx
+++ b/src/components/InspoCaptureButton.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Camera } from 'lucide-react';
+import { Dumbbell } from 'lucide-react';
 import { apiBase, fetchJsonAuthed } from '@/lib/api/client';
 import { onNativeBurstTrigger, savePhotoToLibrary } from '@/lib/inspo-burst-control';
 import { db } from '@/db/local';
@@ -258,7 +258,7 @@ export function InspoCaptureButton() {
         {capturing ? (
           <span className="h-5 w-5 rounded-full border-2 border-white/30 border-t-white animate-spin" />
         ) : (
-          <Camera className="h-5 w-5 text-white" strokeWidth={2} />
+          <Dumbbell className="h-5 w-5 text-white" strokeWidth={2} />
         )}
       </button>
     </>


### PR DESCRIPTION
## Summary

Web-first iPad support (autoplan reviewed) + swap inspo capture icon for Dumbbell.

- PWA manifest: remove portrait orientation lock
- Viewport: remove userScalable: false (enables pinch-zoom on iPad)
- Tailwind md:/lg: responsive CSS across 6 body-comp routes:
  /measurements (3-pane iPad grid with InBody primary), /measurements/inbody/{detail,compare,new}, /measurements/goals, /body-spec
- Chart enrichment: goal + previous-scan reference lines on InBody trend, multi-site tape overlay at lg:
- URL-driven mobile tab state (fixes existing ?tab= round-trip bug)
- InspoCaptureButton: Camera icon -> Dumbbell

No native iOS changes, no Xcode work, no new components.

Visual QA at 500/810/1080px: layouts clean, zero horizontal scroll, all tests pass.

Plan: /Users/lewis/.gstack/projects/lewcart-Iron/lewis-staging-plan-20260420-173301.md

## Test plan
- [x] npm test (755/755)
- [x] npm run build (all 6 routes still static-exportable)
- [x] npm run lint
- [x] Visual QA at 500/810/1080
- [ ] Production deploy: verify iPad Safari rotation + pinch-zoom live