### PR TITLE
feat(mcp): complete nutrition write surface

### DIFF
--- a/src/app/api/mcp/mcp-nutrition.test.ts
+++ b/src/app/api/mcp/mcp-nutrition.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/lib/api-auth', () => ({
 vi.mock('@/db/db', () => ({
   query: vi.fn(),
   queryOne: vi.fn(),
+  transaction: vi.fn(),
 }));
 
 // Helpers for JSON-RPC requests
@@ -30,13 +31,16 @@ function toolCall(name: string, args: Record<string, unknown> = {}) {
 describe('get_nutrition_plan', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('returns week_plan grouped by day', async () => {
+  it('returns week_plan grouped by day with macros + targets', async () => {
     const db = await import('@/db/db');
     vi.mocked(db.query).mockResolvedValueOnce([
-      { day_of_week: 0, meal_slot: 'breakfast', meal_name: 'Oats', protein_g: 30, calories: 400, sort_order: 0 },
-      { day_of_week: 0, meal_slot: 'lunch', meal_name: 'Chicken', protein_g: 50, calories: 550, sort_order: 1 },
-      { day_of_week: 1, meal_slot: 'breakfast', meal_name: 'Eggs', protein_g: 25, calories: 350, sort_order: 0 },
+      { uuid: 'u1', day_of_week: 0, meal_slot: 'breakfast', meal_name: 'Oats', protein_g: 30, carbs_g: 60, fat_g: 8, calories: 400, quality_rating: 4, sort_order: 0 },
+      { uuid: 'u2', day_of_week: 0, meal_slot: 'lunch', meal_name: 'Chicken', protein_g: 50, carbs_g: 70, fat_g: 10, calories: 550, quality_rating: null, sort_order: 1 },
+      { uuid: 'u3', day_of_week: 1, meal_slot: 'breakfast', meal_name: 'Eggs', protein_g: 25, carbs_g: 5, fat_g: 20, calories: 350, quality_rating: null, sort_order: 0 },
     ]);
+    vi.mocked(db.queryOne).mockResolvedValueOnce({
+      calories: 2200, protein_g: 160, carbs_g: 220, fat_g: 70,
+    });
 
     const { POST } = await import('./route');
     const res = await POST(toolCall('get_nutrition_plan'));
@@ -47,14 +51,19 @@ describe('get_nutrition_plan', () => {
     expect(parsed.week_plan).toHaveLength(2);
     expect(parsed.week_plan[0].day).toBe('Mon');
     expect(parsed.week_plan[0].meals).toHaveLength(2);
-    expect(parsed.week_plan[0].meals[0]).toMatchObject({ slot: 'breakfast', description: 'Oats', calories: 400, protein_g: 30 });
+    expect(parsed.week_plan[0].meals[0]).toMatchObject({
+      uuid: 'u1', slot: 'breakfast', description: 'Oats',
+      calories: 400, protein_g: 30, carbs_g: 60, fat_g: 8, quality_rating: 4,
+    });
     expect(parsed.week_plan[1].day).toBe('Tue');
+    expect(parsed.targets).toEqual({ calories: 2200, protein_g: 160, carbs_g: 220, fat_g: 70 });
     expect(parsed.compliance_7d).toBeUndefined();
   });
 
-  it('returns empty week_plan when no meals exist', async () => {
+  it('returns empty week_plan and null targets when nothing stored', async () => {
     const db = await import('@/db/db');
     vi.mocked(db.query).mockResolvedValueOnce([]);
+    vi.mocked(db.queryOne).mockResolvedValueOnce(null);
 
     const { POST } = await import('./route');
     const res = await POST(toolCall('get_nutrition_plan'));
@@ -62,16 +71,15 @@ describe('get_nutrition_plan', () => {
 
     const parsed = JSON.parse(body.result.content[0].text);
     expect(parsed.week_plan).toEqual([]);
+    expect(parsed.targets).toBeNull();
   });
 
   it('includes compliance_7d when include_compliance=true', async () => {
     const db = await import('@/db/db');
     vi.mocked(db.query).mockResolvedValueOnce([]);
-    vi.mocked(db.queryOne).mockResolvedValueOnce({
-      avg_calories: '2100.5',
-      avg_protein: '160.3',
-      logged_days: '5',
-    });
+    vi.mocked(db.queryOne)
+      .mockResolvedValueOnce(null) // targets
+      .mockResolvedValueOnce({ avg_calories: '2100.5', avg_protein: '160.3', logged_days: '5' });
 
     const { POST } = await import('./route');
     const res = await POST(toolCall('get_nutrition_plan', { include_compliance: true }));
@@ -84,7 +92,9 @@ describe('get_nutrition_plan', () => {
   it('returns null values in compliance_7d when no logs exist', async () => {
     const db = await import('@/db/db');
     vi.mocked(db.query).mockResolvedValueOnce([]);
-    vi.mocked(db.queryOne).mockResolvedValueOnce({ avg_calories: null, avg_protein: null, logged_days: '0' });
+    vi.mocked(db.queryOne)
+      .mockResolvedValueOnce(null) // targets
+      .mockResolvedValueOnce({ avg_calories: null, avg_protein: null, logged_days: '0' });
 
     const { POST } = await import('./route');
     const res = await POST(toolCall('get_nutrition_plan', { include_compliance: true }));
@@ -100,9 +110,9 @@ describe('get_nutrition_plan', () => {
 describe('load_nutrition_plan', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('deletes existing meals and inserts new ones', async () => {
+  it('runs DELETE + N INSERTs in a single transaction', async () => {
     const db = await import('@/db/db');
-    vi.mocked(db.query).mockResolvedValue([]);
+    vi.mocked(db.transaction).mockResolvedValue(undefined);
 
     const { POST } = await import('./route');
     const res = await POST(toolCall('load_nutrition_plan', {
@@ -114,12 +124,7 @@ describe('load_nutrition_plan', () => {
             { slot: 'lunch', description: 'Chicken rice', calories: 600, protein_g: 50 },
           ],
         },
-        {
-          day: 'Tue',
-          meals: [
-            { slot: 'breakfast', description: 'Eggs', calories: 350, protein_g: 25 },
-          ],
-        },
+        { day: 'Tue', meals: [{ slot: 'breakfast', description: 'Eggs', calories: 350, protein_g: 25 }] },
       ],
     }));
 
@@ -130,82 +135,256 @@ describe('load_nutrition_plan', () => {
     expect(parsed.meals_created).toBe(3);
     expect(parsed.weeks_loaded).toBe(2);
 
-    // First call should be DELETE
-    expect(vi.mocked(db.query).mock.calls[0][0]).toMatch(/DELETE FROM nutrition_week_meals/);
-    // Subsequent calls are INSERTs
-    const insertCalls = vi.mocked(db.query).mock.calls.slice(1);
-    expect(insertCalls).toHaveLength(3);
-    // Mon = day_of_week 0
-    expect(insertCalls[0][1]).toContain(0);
-    // Tue = day_of_week 1
-    expect(insertCalls[2][1]).toContain(1);
+    expect(vi.mocked(db.transaction)).toHaveBeenCalledTimes(1);
+    const stmts = vi.mocked(db.transaction).mock.calls[0][0] as Array<{ text: string; params?: unknown[] }>;
+    // DELETE + 3 INSERTs
+    expect(stmts).toHaveLength(4);
+    expect(stmts[0].text).toMatch(/DELETE FROM nutrition_week_meals/);
+    expect(stmts[1].text).toMatch(/INSERT INTO nutrition_week_meals/);
+    expect(stmts[1].params?.[1]).toBe(0); // Mon
+    expect(stmts[3].params?.[1]).toBe(1); // Tue
   });
 
   it('maps numeric day (1-7) to day_of_week (0-6)', async () => {
     const db = await import('@/db/db');
-    vi.mocked(db.query).mockResolvedValue([]);
+    vi.mocked(db.transaction).mockResolvedValue(undefined);
 
     const { POST } = await import('./route');
     await POST(toolCall('load_nutrition_plan', {
-      days: [
-        { day: 7, meals: [{ slot: 'dinner', description: 'Sunday roast', calories: 800 }] },
-      ],
+      days: [{ day: 7, meals: [{ slot: 'dinner', description: 'Sunday roast', calories: 800 }] }],
     }));
 
-    const insertArgs = vi.mocked(db.query).mock.calls[1][1] as unknown[];
-    expect(insertArgs[1]).toBe(6); // day 7 → index 6 (Sun)
+    const stmts = vi.mocked(db.transaction).mock.calls[0][0] as Array<{ text: string; params?: unknown[] }>;
+    expect(stmts[1].params?.[1]).toBe(6); // day 7 → index 6 (Sun)
   });
 
   it('maps full day names correctly', async () => {
     const db = await import('@/db/db');
-    vi.mocked(db.query).mockResolvedValue([]);
+    vi.mocked(db.transaction).mockResolvedValue(undefined);
 
     const { POST } = await import('./route');
     await POST(toolCall('load_nutrition_plan', {
-      days: [
-        { day: 'Friday', meals: [{ slot: 'lunch', description: 'Salad' }] },
-      ],
+      days: [{ day: 'Friday', meals: [{ slot: 'lunch', description: 'Salad' }] }],
     }));
 
-    const insertArgs = vi.mocked(db.query).mock.calls[1][1] as unknown[];
-    expect(insertArgs[1]).toBe(4); // Fri = 4
+    const stmts = vi.mocked(db.transaction).mock.calls[0][0] as Array<{ text: string; params?: unknown[] }>;
+    expect(stmts[1].params?.[1]).toBe(4); // Fri = 4
   });
 
-  it('notes unstorable fields (carbs_g, fat_g, targets) without failing', async () => {
+  it('persists carbs_g, fat_g, quality_rating, and targets', async () => {
     const db = await import('@/db/db');
-    vi.mocked(db.query).mockResolvedValue([]);
+    vi.mocked(db.transaction).mockResolvedValue(undefined);
 
     const { POST } = await import('./route');
     const res = await POST(toolCall('load_nutrition_plan', {
       days: [
         {
           day: 'Mon',
-          meals: [{ slot: 'breakfast', description: 'Oats', carbs_g: 60, fat_g: 8 }],
+          meals: [{ slot: 'breakfast', description: 'Oats', calories: 400, protein_g: 30, carbs_g: 60, fat_g: 8, quality_rating: 4 }],
         },
       ],
-      targets: { calories: 2200, protein_g: 160 },
+      targets: { calories: 2200, protein_g: 160, carbs_g: 220, fat_g: 70 },
     }));
 
     const body = await res.json();
     const parsed = JSON.parse(body.result.content[0].text);
     expect(parsed.success).toBe(true);
-    expect(parsed.notes).toContain('targets not stored (no targets table in schema)');
-    expect(parsed.notes).toContain('carbs_g and fat_g not stored (columns absent from nutrition_week_meals)');
+    expect(parsed.meals_created).toBe(1);
+    expect(parsed.targets_set).toBe(true);
+
+    const stmts = vi.mocked(db.transaction).mock.calls[0][0] as Array<{ text: string; params?: unknown[] }>;
+    // DELETE, INSERT meal, INSERT targets upsert
+    expect(stmts).toHaveLength(3);
+    expect(stmts[0].text).toMatch(/DELETE FROM nutrition_week_meals/);
+    expect(stmts[1].text).toMatch(/INSERT INTO nutrition_week_meals/);
+    const mealArgs = stmts[1].params as unknown[];
+    // [uuid, dow, slot, name, protein, carbs, fat, calories, quality, sort_order]
+    expect(mealArgs[4]).toBe(30);
+    expect(mealArgs[5]).toBe(60);
+    expect(mealArgs[6]).toBe(8);
+    expect(mealArgs[7]).toBe(400);
+    expect(mealArgs[8]).toBe(4);
+
+    expect(stmts[2].text).toMatch(/INSERT INTO nutrition_targets/);
+    expect(stmts[2].params).toEqual([2200, 160, 220, 70]);
   });
 
-  it('returns no notes field when no unstorable fields present', async () => {
+  it('skips targets upsert when targets not supplied', async () => {
     const db = await import('@/db/db');
-    vi.mocked(db.query).mockResolvedValue([]);
+    vi.mocked(db.transaction).mockResolvedValue(undefined);
 
     const { POST } = await import('./route');
     const res = await POST(toolCall('load_nutrition_plan', {
-      days: [
-        { day: 'Mon', meals: [{ slot: 'breakfast', description: 'Oats', calories: 400, protein_g: 30 }] },
-      ],
+      days: [{ day: 'Mon', meals: [{ slot: 'breakfast', description: 'Oats', calories: 400, protein_g: 30 }] }],
     }));
 
     const body = await res.json();
     const parsed = JSON.parse(body.result.content[0].text);
-    expect(parsed.notes).toBeUndefined();
+    expect(parsed.targets_set).toBe(false);
+
+    const stmts = vi.mocked(db.transaction).mock.calls[0][0] as Array<{ text: string; params?: unknown[] }>;
+    expect(stmts.some(s => /nutrition_targets/.test(s.text))).toBe(false);
+  });
+});
+
+// ── log_nutrition_meal ────────────────────────────────────────────────────────
+
+describe('log_nutrition_meal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('inserts a meal log row', async () => {
+    const db = await import('@/db/db');
+    vi.mocked(db.queryOne).mockResolvedValueOnce({ uuid: 'row-1', meal_name: 'Protein oats' });
+
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('log_nutrition_meal', {
+      meal_type: 'breakfast',
+      meal_name: 'Protein oats',
+      calories: 420,
+      protein_g: 35,
+      carbs_g: 55,
+      fat_g: 9,
+      status: 'planned',
+    }));
+
+    const body = await res.json();
+    const parsed = JSON.parse(body.result.content[0].text);
+    expect(parsed.uuid).toBe('row-1');
+
+    const call = vi.mocked(db.queryOne).mock.calls[0];
+    expect(call[0]).toMatch(/INSERT INTO nutrition_logs/);
+    const args = call[1] as unknown[];
+    // [uuid, logged_at, meal_type, meal_name, cal, prot, carb, fat, notes, tpl, status]
+    expect(args[2]).toBe('breakfast');
+    expect(args[3]).toBe('Protein oats');
+    expect(args[10]).toBe('planned');
+  });
+
+  it('rejects invalid meal_type', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('log_nutrition_meal', { meal_type: 'brunch' }));
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/meal_type must be/);
+  });
+
+  it('rejects invalid status', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('log_nutrition_meal', { status: 'freeform' }));
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/status must be/);
+  });
+});
+
+// ── set_nutrition_day_notes ───────────────────────────────────────────────────
+
+describe('set_nutrition_day_notes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('upserts hydration + notes for a given date', async () => {
+    const db = await import('@/db/db');
+    vi.mocked(db.queryOne).mockResolvedValueOnce({ date: '2026-04-20', hydration_ml: 3000, notes: 'low-carb day' });
+
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('set_nutrition_day_notes', {
+      date: '2026-04-20',
+      hydration_ml: 3000,
+      notes: 'low-carb day',
+    }));
+
+    const body = await res.json();
+    const parsed = JSON.parse(body.result.content[0].text);
+    expect(parsed.hydration_ml).toBe(3000);
+
+    const call = vi.mocked(db.queryOne).mock.calls[0];
+    expect(call[0]).toMatch(/INSERT INTO nutrition_day_notes/);
+    expect(call[0]).toMatch(/ON CONFLICT \(date\) DO UPDATE/);
+  });
+
+  it('rejects bad date format', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('set_nutrition_day_notes', { date: '04/20/2026' }));
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/YYYY-MM-DD/);
+  });
+});
+
+// ── set_nutrition_targets ─────────────────────────────────────────────────────
+
+describe('set_nutrition_targets', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('upserts the singleton targets row', async () => {
+    const db = await import('@/db/db');
+    vi.mocked(db.queryOne).mockResolvedValueOnce({ id: 1, calories: 2500, protein_g: 180, carbs_g: 250, fat_g: 80 });
+
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('set_nutrition_targets', {
+      calories: 2500, protein_g: 180, carbs_g: 250, fat_g: 80,
+    }));
+
+    const body = await res.json();
+    const parsed = JSON.parse(body.result.content[0].text);
+    expect(parsed.calories).toBe(2500);
+
+    const call = vi.mocked(db.queryOne).mock.calls[0];
+    expect(call[0]).toMatch(/INSERT INTO nutrition_targets/);
+    expect(call[0]).toMatch(/ON CONFLICT \(id\) DO UPDATE/);
+    expect(call[1]).toEqual([2500, 180, 250, 80]);
+  });
+});
+
+// ── update_week_meal ──────────────────────────────────────────────────────────
+
+describe('update_week_meal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates only the provided fields', async () => {
+    const db = await import('@/db/db');
+    vi.mocked(db.queryOne).mockResolvedValueOnce({ uuid: 'meal-1', meal_name: 'Steak + rice', calories: 800 });
+
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('update_week_meal', {
+      uuid: 'meal-1',
+      meal_name: 'Steak + rice',
+      calories: 800,
+    }));
+
+    const body = await res.json();
+    const parsed = JSON.parse(body.result.content[0].text);
+    expect(parsed.meal_name).toBe('Steak + rice');
+
+    const call = vi.mocked(db.queryOne).mock.calls[0];
+    expect(call[0]).toMatch(/UPDATE nutrition_week_meals SET meal_name = \$1, calories = \$2 WHERE uuid = \$3/);
+    expect(call[1]).toEqual(['Steak + rice', 800, 'meal-1']);
+  });
+
+  it('errors when uuid missing', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('update_week_meal', { calories: 500 }));
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/uuid is required/);
+  });
+
+  it('errors when no fields to update', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('update_week_meal', { uuid: 'meal-1' }));
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/No fields to update/);
+  });
+
+  it('returns not found when uuid does not exist', async () => {
+    const db = await import('@/db/db');
+    vi.mocked(db.queryOne).mockResolvedValueOnce(null);
+
+    const { POST } = await import('./route');
+    const res = await POST(toolCall('update_week_meal', { uuid: 'nope', calories: 1 }));
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/Meal not found/);
   });
 });

--- a/src/db/migrations/015_nutrition_complete.sql
+++ b/src/db/migrations/015_nutrition_complete.sql
@@ -1,0 +1,19 @@
+-- Migration 015: Fill nutrition schema gaps so MCP can round-trip a full plan.
+--
+-- Previously nutrition_week_meals stored only protein + calories (carbs/fat
+-- were dropped on write), and there was no place to persist daily macro
+-- targets. This migration:
+--   1. Adds carbs_g and fat_g columns to nutrition_week_meals.
+--   2. Adds a singleton nutrition_targets table (id = 1) for daily macro targets.
+
+ALTER TABLE nutrition_week_meals ADD COLUMN IF NOT EXISTS carbs_g NUMERIC;
+ALTER TABLE nutrition_week_meals ADD COLUMN IF NOT EXISTS fat_g NUMERIC;
+
+CREATE TABLE IF NOT EXISTS nutrition_targets (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  calories NUMERIC,
+  protein_g NUMERIC,
+  carbs_g NUMERIC,
+  fat_g NUMERIC,
+  updated_at TIMESTAMP DEFAULT NOW()
+);

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -6,7 +6,7 @@
  * `executeTool` — they never touch DB logic directly.
  */
 
-import { query, queryOne } from '@/db/db';
+import { query, queryOne, transaction } from '@/db/db';
 
 // ── Result helpers ────────────────────────────────────────────────────────────
 
@@ -271,7 +271,8 @@ async function getActiveRoutine() {
 
 async function getActiveNutritionPlan() {
   const meals = await query(`
-    SELECT day_of_week, meal_slot, meal_name, protein_g, calories, sort_order
+    SELECT uuid, day_of_week, meal_slot, meal_name,
+           protein_g, carbs_g, fat_g, calories, quality_rating, sort_order
     FROM nutrition_week_meals
     ORDER BY day_of_week, sort_order
   `);
@@ -282,10 +283,12 @@ async function getNutritionPlan(args: Record<string, unknown>) {
   const includeCompliance = args.include_compliance === true;
 
   const meals = await query<{
-    day_of_week: number; meal_slot: string; meal_name: string;
-    protein_g: number | null; calories: number | null; sort_order: number;
+    uuid: string; day_of_week: number; meal_slot: string; meal_name: string;
+    protein_g: number | null; carbs_g: number | null; fat_g: number | null;
+    calories: number | null; quality_rating: number | null; sort_order: number;
   }>(`
-    SELECT day_of_week, meal_slot, meal_name, protein_g, calories, sort_order
+    SELECT uuid, day_of_week, meal_slot, meal_name,
+           protein_g, carbs_g, fat_g, calories, quality_rating, sort_order
     FROM nutrition_week_meals
     ORDER BY day_of_week, sort_order
   `);
@@ -301,14 +304,23 @@ async function getNutritionPlan(args: Record<string, unknown>) {
     .map(([dow, dayMeals]) => ({
       day: DOW_NAMES[dow] ?? String(dow),
       meals: dayMeals.map(m => ({
+        uuid: m.uuid,
         slot: m.meal_slot,
         description: m.meal_name,
         calories: m.calories,
         protein_g: m.protein_g,
+        carbs_g: m.carbs_g,
+        fat_g: m.fat_g,
+        quality_rating: m.quality_rating,
       })),
     }));
 
-  const result: Record<string, unknown> = { week_plan };
+  const targets = await queryOne<{
+    calories: number | null; protein_g: number | null;
+    carbs_g: number | null; fat_g: number | null;
+  }>(`SELECT calories, protein_g, carbs_g, fat_g FROM nutrition_targets WHERE id = 1`);
+
+  const result: Record<string, unknown> = { week_plan, targets: targets ?? null };
 
   if (includeCompliance) {
     const compliance = await queryOne<{
@@ -1053,40 +1065,167 @@ async function loadNutritionPlan(args: Record<string, unknown>) {
       meals: Array<{
         slot: string; description: string; calories?: number;
         protein_g?: number; carbs_g?: number; fat_g?: number;
+        quality_rating?: number;
       }>;
     }>;
     targets?: { calories?: number; protein_g?: number; carbs_g?: number; fat_g?: number };
   };
 
-  await query('DELETE FROM nutrition_week_meals');
+  const statements: Array<{ text: string; params?: unknown[] }> = [
+    { text: 'DELETE FROM nutrition_week_meals' },
+  ];
 
   let mealCount = 0;
   for (const d of days) {
     const dow = parseDayOfWeek(d.day as string | number);
     for (let i = 0; i < d.meals.length; i++) {
       const m = d.meals[i];
-      await query(
-        `INSERT INTO nutrition_week_meals (uuid, day_of_week, meal_slot, meal_name, protein_g, calories, sort_order)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-        [crypto.randomUUID(), dow, m.slot, m.description, m.protein_g ?? null, m.calories ?? null, i]
-      );
+      statements.push({
+        text: `INSERT INTO nutrition_week_meals
+           (uuid, day_of_week, meal_slot, meal_name,
+            protein_g, carbs_g, fat_g, calories, quality_rating, sort_order)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        params: [
+          crypto.randomUUID(), dow, m.slot, m.description,
+          m.protein_g ?? null, m.carbs_g ?? null, m.fat_g ?? null,
+          m.calories ?? null, m.quality_rating ?? null, i,
+        ],
+      });
       mealCount++;
     }
   }
 
-  const notes: string[] = [];
-  if (targets) notes.push('targets not stored (no targets table in schema)');
-  const hasUnstorableFields = days.some(d =>
-    d.meals.some(m => m.carbs_g !== undefined || m.fat_g !== undefined)
-  );
-  if (hasUnstorableFields) notes.push('carbs_g and fat_g not stored (columns absent from nutrition_week_meals)');
+  if (targets) {
+    statements.push({
+      text: `INSERT INTO nutrition_targets (id, calories, protein_g, carbs_g, fat_g, updated_at)
+       VALUES (1, $1, $2, $3, $4, NOW())
+       ON CONFLICT (id) DO UPDATE SET
+         calories = EXCLUDED.calories,
+         protein_g = EXCLUDED.protein_g,
+         carbs_g = EXCLUDED.carbs_g,
+         fat_g = EXCLUDED.fat_g,
+         updated_at = NOW()`,
+      params: [targets.calories ?? null, targets.protein_g ?? null, targets.carbs_g ?? null, targets.fat_g ?? null],
+    });
+  }
+
+  await transaction(statements);
 
   return toolResult({
     success: true,
     meals_created: mealCount,
     weeks_loaded: days.length,
-    ...(notes.length > 0 ? { notes } : {}),
+    targets_set: targets ? true : false,
   });
+}
+
+const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack', 'other'] as const;
+const MEAL_STATUSES = ['planned', 'deviation', 'added'] as const;
+
+async function logNutritionMeal(args: Record<string, unknown>) {
+  const {
+    meal_type = null, meal_name = null, calories, protein_g, carbs_g, fat_g,
+    notes = null, template_meal_id = null, status = null, logged_at,
+  } = args as {
+    meal_type?: string | null; meal_name?: string | null;
+    calories?: number; protein_g?: number; carbs_g?: number; fat_g?: number;
+    notes?: string | null; template_meal_id?: string | null;
+    status?: string | null; logged_at?: string;
+  };
+
+  if (meal_type != null && !MEAL_TYPES.includes(meal_type as typeof MEAL_TYPES[number])) {
+    return toolError(`meal_type must be one of ${MEAL_TYPES.join(', ')}`);
+  }
+  if (status != null && !MEAL_STATUSES.includes(status as typeof MEAL_STATUSES[number])) {
+    return toolError(`status must be one of ${MEAL_STATUSES.join(', ')}`);
+  }
+
+  const row = await queryOne(
+    `INSERT INTO nutrition_logs
+       (uuid, logged_at, meal_type, meal_name, calories, protein_g, carbs_g, fat_g,
+        notes, template_meal_id, status)
+     VALUES ($1, COALESCE($2::timestamp, NOW()), $3, $4, $5, $6, $7, $8, $9, $10, $11)
+     RETURNING *`,
+    [
+      crypto.randomUUID(), logged_at ?? null, meal_type, meal_name,
+      calories ?? null, protein_g ?? null, carbs_g ?? null, fat_g ?? null,
+      notes, template_meal_id, status,
+    ]
+  );
+  return toolResult(row);
+}
+
+async function setNutritionDayNotes(args: Record<string, unknown>) {
+  const { date, hydration_ml = null, notes = null } = args as {
+    date?: string; hydration_ml?: number | null; notes?: string | null;
+  };
+  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return toolError('date is required in YYYY-MM-DD format');
+  }
+
+  const row = await queryOne(
+    `INSERT INTO nutrition_day_notes (uuid, date, hydration_ml, notes, updated_at)
+     VALUES ($1, $2, $3, $4, NOW())
+     ON CONFLICT (date) DO UPDATE SET
+       hydration_ml = COALESCE(EXCLUDED.hydration_ml, nutrition_day_notes.hydration_ml),
+       notes = COALESCE(EXCLUDED.notes, nutrition_day_notes.notes),
+       updated_at = NOW()
+     RETURNING *`,
+    [crypto.randomUUID(), date, hydration_ml, notes]
+  );
+  return toolResult(row);
+}
+
+async function setNutritionTargets(args: Record<string, unknown>) {
+  const { calories = null, protein_g = null, carbs_g = null, fat_g = null } = args as {
+    calories?: number | null; protein_g?: number | null;
+    carbs_g?: number | null; fat_g?: number | null;
+  };
+
+  const row = await queryOne(
+    `INSERT INTO nutrition_targets (id, calories, protein_g, carbs_g, fat_g, updated_at)
+     VALUES (1, $1, $2, $3, $4, NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       calories = EXCLUDED.calories,
+       protein_g = EXCLUDED.protein_g,
+       carbs_g = EXCLUDED.carbs_g,
+       fat_g = EXCLUDED.fat_g,
+       updated_at = NOW()
+     RETURNING *`,
+    [calories, protein_g, carbs_g, fat_g]
+  );
+  return toolResult(row);
+}
+
+async function updateWeekMeal(args: Record<string, unknown>) {
+  const { uuid } = args;
+  if (typeof uuid !== 'string') return toolError('uuid is required');
+
+  const fields: string[] = [];
+  const params: unknown[] = [];
+  let p = 0;
+  const pushField = (col: string, val: unknown) => {
+    fields.push(`${col} = $${++p}`);
+    params.push(val);
+  };
+
+  if (typeof args.meal_slot === 'string') pushField('meal_slot', args.meal_slot);
+  if (typeof args.meal_name === 'string') pushField('meal_name', args.meal_name);
+  if (args.calories !== undefined) pushField('calories', args.calories ?? null);
+  if (args.protein_g !== undefined) pushField('protein_g', args.protein_g ?? null);
+  if (args.carbs_g !== undefined) pushField('carbs_g', args.carbs_g ?? null);
+  if (args.fat_g !== undefined) pushField('fat_g', args.fat_g ?? null);
+  if (args.quality_rating !== undefined) pushField('quality_rating', args.quality_rating ?? null);
+  if (typeof args.sort_order === 'number') pushField('sort_order', args.sort_order);
+
+  if (fields.length === 0) return toolError('No fields to update');
+
+  params.push(uuid);
+  const row = await queryOne(
+    `UPDATE nutrition_week_meals SET ${fields.join(', ')} WHERE uuid = $${++p} RETURNING *`,
+    params
+  );
+  return row ? toolResult(row) : toolError('Meal not found');
 }
 
 async function logBodyComp(args: Record<string, unknown>) {
@@ -1731,7 +1870,7 @@ export const tools: MCPTool[] = [
   },
   {
     name: 'load_nutrition_plan',
-    description: 'Replaces the entire standard-week meal template with a new plan. Accepts days with nested meals.',
+    description: 'Replaces the entire standard-week meal template with a new plan. Accepts days with nested meals and optional daily macro targets.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1751,8 +1890,9 @@ export const tools: MCPTool[] = [
                     description: { type: 'string', description: 'Meal name/description' },
                     calories: { type: 'number' },
                     protein_g: { type: 'number' },
-                    carbs_g: { type: 'number', description: 'Accepted but not stored (column absent from schema)' },
-                    fat_g: { type: 'number', description: 'Accepted but not stored (column absent from schema)' },
+                    carbs_g: { type: 'number' },
+                    fat_g: { type: 'number' },
+                    quality_rating: { type: 'number', description: '1–5 quality rating' },
                   },
                   required: ['slot', 'description'],
                 },
@@ -1763,7 +1903,7 @@ export const tools: MCPTool[] = [
         },
         targets: {
           type: 'object',
-          description: 'Daily macro targets — accepted but not stored (no targets table exists)',
+          description: 'Daily macro targets (upserts the singleton nutrition_targets row).',
           properties: {
             calories: { type: 'number' },
             protein_g: { type: 'number' },
@@ -1775,6 +1915,74 @@ export const tools: MCPTool[] = [
       required: ['days'],
     },
     execute: loadNutritionPlan,
+  },
+  {
+    name: 'update_week_meal',
+    description: 'Partially updates a single meal in the standard-week template by uuid. Only provided fields are changed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        uuid: { type: 'string', description: 'UUID of the nutrition_week_meals row' },
+        meal_slot: { type: 'string', description: 'breakfast | lunch | dinner | snack' },
+        meal_name: { type: 'string' },
+        calories: { type: 'number' },
+        protein_g: { type: 'number' },
+        carbs_g: { type: 'number' },
+        fat_g: { type: 'number' },
+        quality_rating: { type: 'number', description: '1–5' },
+        sort_order: { type: 'number' },
+      },
+      required: ['uuid'],
+    },
+    execute: updateWeekMeal,
+  },
+  {
+    name: 'log_nutrition_meal',
+    description: 'Logs an actual eaten meal to nutrition_logs (compliance + deviation tracking). meal_type one of breakfast|lunch|dinner|snack|other; status one of planned|deviation|added.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        meal_type: { type: 'string', description: 'breakfast | lunch | dinner | snack | other' },
+        meal_name: { type: 'string' },
+        calories: { type: 'number' },
+        protein_g: { type: 'number' },
+        carbs_g: { type: 'number' },
+        fat_g: { type: 'number' },
+        notes: { type: 'string' },
+        template_meal_id: { type: 'string', description: 'UUID of the nutrition_week_meals row this log came from' },
+        status: { type: 'string', description: 'planned | deviation | added' },
+        logged_at: { type: 'string', description: 'ISO timestamp (defaults to now)' },
+      },
+    },
+    execute: logNutritionMeal,
+  },
+  {
+    name: 'set_nutrition_day_notes',
+    description: 'Upserts hydration and free-text notes for a specific calendar day (YYYY-MM-DD). Omitted fields preserve existing values.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        date: { type: 'string', description: 'YYYY-MM-DD' },
+        hydration_ml: { type: 'number' },
+        notes: { type: 'string' },
+      },
+      required: ['date'],
+    },
+    execute: setNutritionDayNotes,
+  },
+  {
+    name: 'set_nutrition_targets',
+    description: 'Replaces the singleton daily-macro-targets row. Omitted fields are set to null — always pass the full set (calories, protein_g, carbs_g, fat_g) if you want all four tracked.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        calories: { type: 'number' },
+        protein_g: { type: 'number' },
+        carbs_g: { type: 'number' },
+        fat_g: { type: 'number' },
+      },
+    },
+    execute: setNutritionTargets,
   },
   {
     name: 'log_body_comp',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import path from 'path';
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.next/**', '**/.claude/worktrees/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- MCP can now round-trip a complete nutrition plan — carbs, fat, targets, day notes, per-meal edits, and actual meal logs
- Migration `015_nutrition_complete.sql`: adds `carbs_g`, `fat_g` to `nutrition_week_meals`; adds singleton `nutrition_targets` table
- Four new MCP tools: `log_nutrition_meal`, `set_nutrition_day_notes`, `set_nutrition_targets`, `update_week_meal`
- `load_nutrition_plan` no longer silently drops `carbs_g`/`fat_g`/`quality_rating`/`targets`; now runs DELETE + inserts + targets upsert inside a single `transaction()`
- Read tools surface the new columns + current targets
- Excludes `.claude/worktrees/**` from vitest so stale agent worktrees don't get picked up as test sources

## Test plan

- [x] `npx vitest run` — 762 tests pass (11 new)
- [x] `npx tsc --noEmit` — no new type errors in touched files
- [ ] Run migration 015 against Neon
- [ ] Exercise each new tool via MCP client end-to-end
- [ ] Update `/nutrition` UI + `src/app/api/nutrition/*` routes to read/write the new fields (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)