### PR TITLE
fix: feed timeline crashes on inbody_scan module

### DIFF
--- a/src/app/feed/feed.test.tsx
+++ b/src/app/feed/feed.test.tsx
@@ -358,3 +358,42 @@ describe('muscleTextColor', () => {
     expect(muscleTextColor(5)).toBe('text-zinc-100');
   });
 });
+
+// ===== MODULE_STYLES completeness =====
+// Guards against server/client type drift: every TimelineModule must have a style.
+// Mirror keys from src/lib/api/feed-types.ts TimelineModule union.
+
+const TIMELINE_MODULES = [
+  'workout',
+  'nutrition',
+  'hrt',
+  'measurement',
+  'wellbeing',
+  'photo',
+  'bodyweight',
+  'body_spec',
+  'inbody_scan',
+  'dysphoria',
+] as const;
+
+// Copy-paste from src/app/feed/page.tsx (keys only; values are tailwind strings)
+const MODULE_STYLE_KEYS = new Set([
+  'workout',
+  'nutrition',
+  'hrt',
+  'measurement',
+  'wellbeing',
+  'photo',
+  'bodyweight',
+  'body_spec',
+  'inbody_scan',
+  'dysphoria',
+]);
+
+describe('MODULE_STYLES completeness', () => {
+  it('has a style for every TimelineModule value', () => {
+    for (const mod of TIMELINE_MODULES) {
+      expect(MODULE_STYLE_KEYS.has(mod)).toBe(true);
+    }
+  });
+});

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -115,6 +115,11 @@ const MODULE_STYLES: Record<TimelineModule, { bg: string; text: string; label: s
     text: 'text-teal-900 dark:text-teal-200',
     label: 'Body Scan',
   },
+  inbody_scan: {
+    bg: 'bg-indigo-100 dark:bg-indigo-950/80',
+    text: 'text-indigo-800 dark:text-indigo-200',
+    label: 'InBody',
+  },
   dysphoria: {
     bg: 'bg-rose-100 dark:bg-rose-950/80',
     text: 'text-rose-800 dark:text-rose-200',
@@ -405,7 +410,11 @@ export default function FeedPage() {
               </div>
             ) : (
               timeline.map((entry) => {
-                const style = MODULE_STYLES[entry.module];
+                const style = MODULE_STYLES[entry.module] ?? {
+                  bg: 'bg-muted',
+                  text: 'text-muted-foreground',
+                  label: entry.module,
+                };
                 return (
                   <div key={`${entry.module}-${entry.id}`} className="flex items-start gap-3">
                     <div className="flex-shrink-0 mt-0.5">

--- a/src/lib/api/feed-types.ts
+++ b/src/lib/api/feed-types.ts
@@ -9,6 +9,7 @@ export type TimelineModule =
   | 'photo'
   | 'bodyweight'
   | 'body_spec'
+  | 'inbody_scan'
   | 'dysphoria';
 
 export interface TimelineEntry {


### PR DESCRIPTION
## Summary

Feed tab crashed with `TypeError: Cannot read properties of undefined (reading 'bg')` as soon as an InBody scan appeared in the timeline.

- Server emits `module: 'inbody_scan'` (`timeline-entries.ts:206`)
- Client `TimelineModule` union (`feed-types.ts`) AND `MODULE_STYLES` map (`feed/page.tsx`) both missed that value
- Lookup `MODULE_STYLES[entry.module]` returned `undefined` → `.bg` access threw

## Fix

- Add `'inbody_scan'` to client `TimelineModule` union
- Add `MODULE_STYLES['inbody_scan']` entry (indigo color)
- Defensive `?? { bg: 'bg-muted', ... }` fallback at the usage site so any future server-added module degrades to a gray chip instead of nuking the page
- Regression test asserts `MODULE_STYLES` covers every `TimelineModule` value

## Test plan
- [x] `npx vitest run src/app/feed` — 44/44 pass
- [x] `npm run build` — clean
- [ ] Verify prod `/feed` loads without error after deploy