### PR TITLE
feat(healthkit): full HealthKit integration

### DIFF
--- a/ios/App/App/HealthKitPlugin.swift
+++ b/ios/App/App/HealthKitPlugin.swift
@@ -7,19 +7,36 @@ public class HealthKitPlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "HealthKitPlugin"
     public let jsName = "HealthKit"
     public let pluginMethods: [CAPPluginMethod] = [
+        // Core
         CAPPluginMethod(name: "isAvailable", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "requestPermissions", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "saveWorkout", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "checkPermissionStatus", returnType: CAPPluginReturnPromise),
+        // Legacy reads (kept for backwards compat with existing TS callers)
         CAPPluginMethod(name: "getSteps", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getActiveCalories", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getRecentWorkouts", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getWorkouts", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getHeartRate", returnType: CAPPluginReturnPromise),
+        // New anchored / aggregated reads
+        CAPPluginMethod(name: "fetchDailyAggregates", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "fetchSleepNights", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "fetchWorkouts", returnType: CAPPluginReturnPromise),
+        // Writes
+        CAPPluginMethod(name: "saveWorkout", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "saveNutrition", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "saveBodyComposition", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "deleteSamples", returnType: CAPPluginReturnPromise),
     ]
 
     private let healthStore = HKHealthStore()
 
+    // MARK: - Availability
+
     @objc public func isAvailable(_ call: CAPPluginCall) {
         call.resolve(["available": HKHealthStore.isHealthDataAvailable()])
     }
+
+    // MARK: - Authorization
 
     @objc public override func requestPermissions(_ call: CAPPluginCall) {
         guard HKHealthStore.isHealthDataAvailable() else {
@@ -27,24 +44,7 @@ public class HealthKitPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        guard let activeEnergyType = HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned),
-              let basalEnergyType = HKQuantityType.quantityType(forIdentifier: .basalEnergyBurned),
-              let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount) else {
-            call.reject("Failed to create HealthKit quantity types")
-            return
-        }
-
-        let writeTypes: Set<HKSampleType> = [
-            activeEnergyType,
-            basalEnergyType,
-            HKObjectType.workoutType()
-        ]
-
-        let readTypes: Set<HKObjectType> = [
-            stepsType,
-            activeEnergyType,
-            HKObjectType.workoutType()
-        ]
+        let (readTypes, writeTypes) = Self.allRequestedTypes()
 
         healthStore.requestAuthorization(toShare: writeTypes, read: readTypes) { success, error in
             if let error = error {
@@ -55,52 +55,42 @@ public class HealthKitPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    /// Returns sharing auth status per tracked type. iOS hides READ status for privacy;
+    /// read types always return 'notDetermined'. Write types reflect real status.
+    @objc public func checkPermissionStatus(_ call: CAPPluginCall) {
+        var statuses: [String: String] = [:]
+        // Read-only types from HK always report notDetermined — document that via return value.
+        for key in ["stepCount", "activeEnergyBurned", "basalEnergyBurned",
+                    "heartRate", "heartRateVariabilitySDNN", "restingHeartRate",
+                    "vo2Max", "appleExerciseTime", "sleepAnalysis",
+                    "distanceWalkingRunning"] {
+            statuses[key] = "notDetermined"
+        }
+        // Write types we can read authoritatively.
+        statuses["workout"] = Self.authStatusString(healthStore.authorizationStatus(for: HKObjectType.workoutType()))
+        if let t = HKQuantityType.quantityType(forIdentifier: .bodyMass) {
+            statuses["bodyMass"] = Self.authStatusString(healthStore.authorizationStatus(for: t))
+        }
+        if let t = HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage) {
+            statuses["bodyFatPercentage"] = Self.authStatusString(healthStore.authorizationStatus(for: t))
+        }
+        if let t = HKQuantityType.quantityType(forIdentifier: .leanBodyMass) {
+            statuses["leanBodyMass"] = Self.authStatusString(healthStore.authorizationStatus(for: t))
+        }
+        if let t = HKQuantityType.quantityType(forIdentifier: .dietaryEnergyConsumed) {
+            statuses["dietaryEnergyConsumed"] = Self.authStatusString(healthStore.authorizationStatus(for: t))
+        }
+        call.resolve(["statuses": statuses])
+    }
+
+    // MARK: - Legacy reads (backwards-compat with pre-expansion TS bridge)
+
     @objc public func getSteps(_ call: CAPPluginCall) {
-        guard HKHealthStore.isHealthDataAvailable() else {
-            call.resolve(["value": 0])
-            return
-        }
-
-        guard let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount) else {
-            call.resolve(["value": 0])
-            return
-        }
-
-        let startMs = call.getDouble("startTime") ?? startOfTodayMs()
-        let endMs = call.getDouble("endTime") ?? Double(Date().timeIntervalSince1970 * 1000)
-        let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
-        let endDate = Date(timeIntervalSince1970: endMs / 1000.0)
-
-        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
-        let query = HKStatisticsQuery(quantityType: stepsType, quantitySamplePredicate: predicate, options: .cumulativeSum) { _, result, _ in
-            let value = result?.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0
-            call.resolve(["value": Int(value)])
-        }
-        healthStore.execute(query)
+        quantitySum(call: call, identifier: .stepCount, unit: HKUnit.count())
     }
 
     @objc public func getActiveCalories(_ call: CAPPluginCall) {
-        guard HKHealthStore.isHealthDataAvailable() else {
-            call.resolve(["value": 0])
-            return
-        }
-
-        guard let activeEnergyType = HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned) else {
-            call.resolve(["value": 0])
-            return
-        }
-
-        let startMs = call.getDouble("startTime") ?? startOfTodayMs()
-        let endMs = call.getDouble("endTime") ?? Double(Date().timeIntervalSince1970 * 1000)
-        let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
-        let endDate = Date(timeIntervalSince1970: endMs / 1000.0)
-
-        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
-        let query = HKStatisticsQuery(quantityType: activeEnergyType, quantitySamplePredicate: predicate, options: .cumulativeSum) { _, result, _ in
-            let value = result?.sumQuantity()?.doubleValue(for: .kilocalorie()) ?? 0
-            call.resolve(["value": Int(value)])
-        }
-        healthStore.execute(query)
+        quantitySum(call: call, identifier: .activeEnergyBurned, unit: .kilocalorie())
     }
 
     @objc public func getRecentWorkouts(_ call: CAPPluginCall) {
@@ -108,28 +98,259 @@ public class HealthKitPlugin: CAPPlugin, CAPBridgedPlugin {
             call.resolve(["workouts": []])
             return
         }
-
         let startMs = call.getDouble("startTime") ?? sevenDaysAgoMs()
         let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
-
         let predicate = HKQuery.predicateForSamples(withStart: startDate, end: Date(), options: .strictStartDate)
-        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
-        let query = HKSampleQuery(sampleType: HKObjectType.workoutType(), predicate: predicate, limit: 10, sortDescriptors: [sortDescriptor]) { _, samples, _ in
-            let workouts = (samples as? [HKWorkout] ?? []).map { w -> [String: Any] in
-                let durationMins = w.duration / 60.0
-                let calories = w.totalEnergyBurned?.doubleValue(for: .kilocalorie()) ?? 0
-                return [
-                    "startTime": w.startDate.timeIntervalSince1970 * 1000,
-                    "endTime": w.endDate.timeIntervalSince1970 * 1000,
-                    "durationMinutes": Int(durationMins),
-                    "activeCalories": Int(calories),
-                    "activityType": self.activityTypeName(w.workoutActivityType),
-                ]
-            }
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
+        let query = HKSampleQuery(sampleType: HKObjectType.workoutType(), predicate: predicate,
+                                  limit: 10, sortDescriptors: [sort]) { [weak self] _, samples, _ in
+            let workouts = (samples as? [HKWorkout] ?? []).map { self?.workoutToLegacyDict($0) ?? [:] }
             call.resolve(["workouts": workouts])
         }
         healthStore.execute(query)
     }
+
+    @objc public func getWorkouts(_ call: CAPPluginCall) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            call.resolve(["workouts": []])
+            return
+        }
+        let startMs = call.getDouble("startTime") ?? sevenDaysAgoMs()
+        let endMs = call.getDouble("endTime") ?? Date().timeIntervalSince1970 * 1000
+        let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
+        let endDate = Date(timeIntervalSince1970: endMs / 1000.0)
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
+        let query = HKSampleQuery(sampleType: HKObjectType.workoutType(), predicate: predicate,
+                                  limit: HKObjectQueryNoLimit, sortDescriptors: [sort]) { [weak self] _, samples, _ in
+            let workouts = (samples as? [HKWorkout] ?? []).map { self?.workoutToLegacyDict($0) ?? [:] }
+            call.resolve(["workouts": workouts])
+        }
+        healthStore.execute(query)
+    }
+
+    @objc public func getHeartRate(_ call: CAPPluginCall) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            call.resolve(["samples": []])
+            return
+        }
+        guard let hrType = HKQuantityType.quantityType(forIdentifier: .heartRate) else {
+            call.resolve(["samples": []])
+            return
+        }
+        let startMs = call.getDouble("startTime") ?? Date().addingTimeInterval(-3600).timeIntervalSince1970 * 1000
+        let endMs = call.getDouble("endTime") ?? Date().timeIntervalSince1970 * 1000
+        let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
+        let endDate = Date(timeIntervalSince1970: endMs / 1000.0)
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
+        let query = HKSampleQuery(sampleType: hrType, predicate: predicate,
+                                  limit: HKObjectQueryNoLimit, sortDescriptors: [sort]) { _, samples, _ in
+            let bpmUnit = HKUnit.count().unitDivided(by: .minute())
+            let out = (samples as? [HKQuantitySample] ?? []).map { s -> [String: Any] in
+                [
+                    "bpm": Int(s.quantity.doubleValue(for: bpmUnit)),
+                    "timestamp": s.startDate.timeIntervalSince1970 * 1000
+                ]
+            }
+            call.resolve(["samples": out])
+        }
+        healthStore.execute(query)
+    }
+
+    // MARK: - New: fetchDailyAggregates (quantity metrics only, NO anchor)
+
+    /// Fetch daily aggregate stats for one or more quantity metrics over a date window.
+    ///
+    /// Per-metric aggregation option:
+    ///   cumulativeSum: steps, active_energy, basal_energy, exercise_minutes
+    ///   discreteAverage+min+max: heart_rate, hrv, resting_hr, vo2_max
+    ///
+    /// HRV and resting HR are filtered to Apple Watch / iPhone native sources
+    /// (bundleIdentifier starting "com.apple.") — averaging Whoop/Watch HRV
+    /// with different methodology produces meaningless numbers.
+    ///
+    /// No anchor — HKStatisticsCollectionQuery has no anchor API. Call site
+    /// supplies a 2-day overlap window via `startTime` to cover late edits.
+    @objc public func fetchDailyAggregates(_ call: CAPPluginCall) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            call.resolve(["results": []])
+            return
+        }
+        guard let metricsArray = call.getArray("metrics") as? [String],
+              let startMs = call.getDouble("startTime") as Double?,
+              let endMs = call.getDouble("endTime") as Double? else {
+            call.reject("metrics, startTime, endTime required")
+            return
+        }
+        let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
+        let endDate = Date(timeIntervalSince1970: endMs / 1000.0)
+
+        // Day boundaries use device calendar. v1.5: configurable user timezone.
+        let cal = Calendar.current
+        let anchor = cal.startOfDay(for: startDate)
+
+        let group = DispatchGroup()
+        var rows: [[String: Any]] = []
+        let rowsLock = NSLock()
+        var firstError: String?
+
+        for metric in metricsArray {
+            guard let spec = Self.metricSpec(metric) else { continue }
+            group.enter()
+
+            let predicateForStart = cal.startOfDay(for: startDate)
+            let basePredicate = HKQuery.predicateForSamples(withStart: predicateForStart, end: endDate, options: .strictStartDate)
+
+            // Note on source filtering: HealthKit rejects generic NSPredicate key
+            // paths like "sourceRevision.source.bundleIdentifier" at query init
+            // (throws NSException → SIGABRT, crashing the whole process). The only
+            // legal source filter is HKQuery.predicateForObjects(from: Set<HKSource>),
+            // which requires an async HKSourceQuery first. Deferred to v1.5; for
+            // v1 we accept all sources. Single-device users (Apple Watch only) are
+            // unaffected. Revisit if multi-source HRV drift becomes a real issue.
+            let predicate = basePredicate
+
+            let query = HKStatisticsCollectionQuery(
+                quantityType: spec.type,
+                quantitySamplePredicate: predicate,
+                options: spec.options,
+                anchorDate: anchor,
+                intervalComponents: DateComponents(day: 1)
+            )
+            query.initialResultsHandler = { _, results, err in
+                defer { group.leave() }
+                if let err = err {
+                    firstError = err.localizedDescription
+                    return
+                }
+                guard let results = results else { return }
+                results.enumerateStatistics(from: anchor, to: endDate) { stats, _ in
+                    let dateStr = Self.ymdString(stats.startDate, calendar: cal)
+                    var row: [String: Any] = [
+                        "metric": metric,
+                        "date": dateStr
+                    ]
+                    if spec.options.contains(.cumulativeSum),
+                       let sumQ = stats.sumQuantity() {
+                        row["value_sum"] = sumQ.doubleValue(for: spec.unit)
+                    }
+                    if spec.options.contains(.discreteAverage),
+                       let avgQ = stats.averageQuantity() {
+                        row["value_avg"] = avgQ.doubleValue(for: spec.unit)
+                    }
+                    if spec.options.contains(.discreteMin),
+                       let minQ = stats.minimumQuantity() {
+                        row["value_min"] = minQ.doubleValue(for: spec.unit)
+                    }
+                    if spec.options.contains(.discreteMax),
+                       let maxQ = stats.maximumQuantity() {
+                        row["value_max"] = maxQ.doubleValue(for: spec.unit)
+                    }
+                    // count: HK doesn't expose per-bucket sample count directly on
+                    // HKStatistics; approximate as "had data" (1) vs "no data" (0).
+                    row["count"] = (stats.sumQuantity() != nil || stats.averageQuantity() != nil) ? 1 : 0
+                    row["source_primary"] = Self.primarySourceId(stats)
+                    rowsLock.lock()
+                    rows.append(row)
+                    rowsLock.unlock()
+                }
+            }
+            healthStore.execute(query)
+        }
+
+        group.notify(queue: .main) {
+            if let err = firstError {
+                call.reject(err)
+                return
+            }
+            call.resolve(["results": rows])
+        }
+    }
+
+    // MARK: - New: fetchSleepNights (anchored, HKCategoryType)
+
+    /// Anchored incremental fetch of sleep samples, grouped into nights.
+    /// A "night" is a contiguous run of sleep/inBed samples with <14h gap,
+    /// keyed to the wake date.
+    @objc public func fetchSleepNights(_ call: CAPPluginCall) {
+        guard HKHealthStore.isHealthDataAvailable(),
+              let sleepType = HKCategoryType.categoryType(forIdentifier: .sleepAnalysis) else {
+            call.resolve(["nights": [], "deleted": [], "nextAnchor": ""])
+            return
+        }
+        let startMs = call.getDouble("startTime") ?? Date().addingTimeInterval(-90*24*3600).timeIntervalSince1970 * 1000
+        let endMs = call.getDouble("endTime") ?? Date().timeIntervalSince1970 * 1000
+        let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
+        let endDate = Date(timeIntervalSince1970: endMs / 1000.0)
+
+        let anchor = Self.decodeAnchor(call.getString("anchor"))
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: [])
+
+        let query = HKAnchoredObjectQuery(
+            type: sleepType,
+            predicate: predicate,
+            anchor: anchor,
+            limit: HKObjectQueryNoLimit
+        ) { [weak self] _, samples, deleted, newAnchor, err in
+            guard let self = self else { return }
+            if let err = err {
+                call.reject(err.localizedDescription)
+                return
+            }
+            let catSamples = (samples as? [HKCategorySample]) ?? []
+            let nights = self.groupSleepIntoNights(catSamples)
+            let deletedUuids = (deleted ?? []).map { $0.uuid.uuidString }
+            let anchorString = Self.encodeAnchor(newAnchor)
+            call.resolve([
+                "nights": nights,
+                "deleted": deletedUuids,
+                "nextAnchor": anchorString
+            ])
+        }
+        healthStore.execute(query)
+    }
+
+    // MARK: - New: fetchWorkouts (anchored)
+
+    /// Anchored incremental fetch of workouts. Returns new + deleted since anchor.
+    @objc public func fetchWorkouts(_ call: CAPPluginCall) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            call.resolve(["workouts": [], "deleted": [], "nextAnchor": ""])
+            return
+        }
+        let startMs = call.getDouble("startTime") ?? Date().addingTimeInterval(-90*24*3600).timeIntervalSince1970 * 1000
+        let endMs = call.getDouble("endTime") ?? Date().timeIntervalSince1970 * 1000
+        let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
+        let endDate = Date(timeIntervalSince1970: endMs / 1000.0)
+
+        let anchor = Self.decodeAnchor(call.getString("anchor"))
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: [])
+
+        let query = HKAnchoredObjectQuery(
+            type: HKObjectType.workoutType(),
+            predicate: predicate,
+            anchor: anchor,
+            limit: HKObjectQueryNoLimit
+        ) { [weak self] _, samples, deleted, newAnchor, err in
+            guard let self = self else { return }
+            if let err = err {
+                call.reject(err.localizedDescription)
+                return
+            }
+            let workouts = ((samples as? [HKWorkout]) ?? []).map { self.workoutToFullDict($0) }
+            let deletedUuids = (deleted ?? []).map { $0.uuid.uuidString }
+            let anchorString = Self.encodeAnchor(newAnchor)
+            call.resolve([
+                "workouts": workouts,
+                "deleted": deletedUuids,
+                "nextAnchor": anchorString
+            ])
+        }
+        healthStore.execute(query)
+    }
+
+    // MARK: - Workout write (existing)
 
     @objc public func saveWorkout(_ call: CAPPluginCall) {
         guard HKHealthStore.isHealthDataAvailable() else {
@@ -167,23 +388,21 @@ public class HealthKitPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let builder = HKWorkoutBuilder(healthStore: healthStore, configuration: configuration, device: .local())
 
-        // Build metadata
         var metadata: [String: Any] = [:]
         if let uuid = call.getString("uuid") {
             metadata[HKMetadataKeyExternalUUID] = uuid
+            metadata["REBIRTH_WORKOUT_UUID"] = uuid
         }
         if let metadataJson = call.getString("metadata") {
-            metadata["ironMetadata"] = metadataJson
+            metadata["rebirthMetadata"] = metadataJson
         }
 
-        builder.beginCollection(withStart: startDate) { [weak self] success, error in
-            guard success, let self = self else {
+        builder.beginCollection(withStart: startDate) { success, error in
+            guard success else {
                 call.reject("Failed to begin workout collection: \(error?.localizedDescription ?? "unknown")")
                 return
             }
 
-            // Critical: add activeEnergyBurned samples BEFORE finishing
-            // — this is what triggers activity ring credit
             let activeEnergy = HKQuantity(unit: .kilocalorie(), doubleValue: activeEnergyKcal)
             let activeSample = HKQuantitySample(
                 type: activeEnergyType,
@@ -204,21 +423,21 @@ public class HealthKitPlugin: CAPPlugin, CAPBridgedPlugin {
                             call.reject("Failed to end workout collection: \(error?.localizedDescription ?? "unknown")")
                             return
                         }
-
                         builder.finishWorkout { workout, error in
                             if let error = error {
                                 call.reject("Failed to finish workout: \(error.localizedDescription)")
                                 return
                             }
-                            call.resolve(["saved": true])
+                            call.resolve([
+                                "saved": true,
+                                "hk_uuid": workout?.uuid.uuidString ?? ""
+                            ])
                         }
                     }
                 }
 
                 if !metadata.isEmpty {
-                    builder.addMetadata(metadata) { _, _ in
-                        finishCollection()
-                    }
+                    builder.addMetadata(metadata) { _, _ in finishCollection() }
                 } else {
                     finishCollection()
                 }
@@ -226,20 +445,458 @@ public class HealthKitPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    // MARK: - New: saveNutrition (atomic multi-sample)
+
+    /// Writes dietary samples (energy + protein + carbs + fat + water) atomically.
+    /// Nil/missing fields are skipped so partial meals still work.
+    @objc public func saveNutrition(_ call: CAPPluginCall) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            call.reject("HealthKit not available")
+            return
+        }
+        guard let tsMs = call.getDouble("timestamp"),
+              let mealUuid = call.getString("mealUuid") else {
+            call.reject("timestamp and mealUuid required")
+            return
+        }
+        let date = Date(timeIntervalSince1970: tsMs / 1000.0)
+        let metadata: [String: Any] = [
+            HKMetadataKeyExternalUUID: mealUuid,
+            "REBIRTH_MEAL_UUID": mealUuid
+        ]
+
+        var samples: [HKSample] = []
+        var typeTags: [String] = []
+
+        func addQuantity(_ identifier: HKQuantityTypeIdentifier, _ unit: HKUnit, _ value: Double?, _ tag: String) {
+            guard let v = value, v > 0, let type = HKQuantityType.quantityType(forIdentifier: identifier) else { return }
+            let qty = HKQuantity(unit: unit, doubleValue: v)
+            let s = HKQuantitySample(type: type, quantity: qty, start: date, end: date, metadata: metadata)
+            samples.append(s)
+            typeTags.append(tag)
+        }
+
+        addQuantity(.dietaryEnergyConsumed, .kilocalorie(), call.getDouble("kcal"), "dietary_energy")
+        addQuantity(.dietaryProtein, .gram(), call.getDouble("proteinG"), "dietary_protein")
+        addQuantity(.dietaryCarbohydrates, .gram(), call.getDouble("carbsG"), "dietary_carbs")
+        addQuantity(.dietaryFatTotal, .gram(), call.getDouble("fatG"), "dietary_fat")
+        addQuantity(.dietaryWater, .literUnit(with: .milli), call.getDouble("waterMl"), "dietary_water")
+
+        if samples.isEmpty {
+            call.resolve(["saved": true, "samples": []])
+            return
+        }
+
+        healthStore.save(samples) { success, error in
+            if let error = error {
+                call.reject(error.localizedDescription)
+                return
+            }
+            if !success {
+                call.reject("HKHealthStore.save returned false")
+                return
+            }
+            let out: [[String: String]] = zip(samples, typeTags).map { (sample, tag) in
+                return ["hk_uuid": sample.uuid.uuidString, "hk_type": tag]
+            }
+            call.resolve(["saved": true, "samples": out])
+        }
+    }
+
+    // MARK: - New: saveBodyComposition
+
+    /// Writes body mass / body fat % / lean mass atomically.
+    @objc public func saveBodyComposition(_ call: CAPPluginCall) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            call.reject("HealthKit not available")
+            return
+        }
+        guard let tsMs = call.getDouble("timestamp"),
+              let inbodyUuid = call.getString("inbodyUuid") else {
+            call.reject("timestamp and inbodyUuid required")
+            return
+        }
+        let date = Date(timeIntervalSince1970: tsMs / 1000.0)
+        // Note: HealthKit has no public "body mass measurement source" metadata key.
+        // Stamping a Rebirth-owned key for our own round-trip tracking.
+        let metadata: [String: Any] = [
+            HKMetadataKeyExternalUUID: inbodyUuid,
+            "REBIRTH_INBODY_UUID": inbodyUuid,
+            "REBIRTH_SOURCE": "inbody_570_bioelectrical_impedance"
+        ]
+
+        var samples: [HKSample] = []
+        var typeTags: [String] = []
+
+        if let kg = call.getDouble("weightKg"), kg > 0,
+           let type = HKQuantityType.quantityType(forIdentifier: .bodyMass) {
+            let qty = HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: kg)
+            samples.append(HKQuantitySample(type: type, quantity: qty, start: date, end: date, metadata: metadata))
+            typeTags.append("body_mass")
+        }
+        if let pct = call.getDouble("bodyFatPct"), pct >= 0,
+           let type = HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage) {
+            // bodyFatPercentage uses percent as 0..1
+            let qty = HKQuantity(unit: HKUnit.percent(), doubleValue: pct / 100.0)
+            samples.append(HKQuantitySample(type: type, quantity: qty, start: date, end: date, metadata: metadata))
+            typeTags.append("body_fat_percentage")
+        }
+        if let leanKg = call.getDouble("leanKg"), leanKg > 0,
+           let type = HKQuantityType.quantityType(forIdentifier: .leanBodyMass) {
+            let qty = HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: leanKg)
+            samples.append(HKQuantitySample(type: type, quantity: qty, start: date, end: date, metadata: metadata))
+            typeTags.append("lean_body_mass")
+        }
+
+        if samples.isEmpty {
+            call.resolve(["saved": true, "samples": []])
+            return
+        }
+
+        healthStore.save(samples) { success, error in
+            if let error = error {
+                call.reject(error.localizedDescription)
+                return
+            }
+            if !success {
+                call.reject("HKHealthStore.save returned false")
+                return
+            }
+            let out: [[String: String]] = zip(samples, typeTags).map { (sample, tag) in
+                return ["hk_uuid": sample.uuid.uuidString, "hk_type": tag]
+            }
+            call.resolve(["saved": true, "samples": out])
+        }
+    }
+
+    // MARK: - New: deleteSamples
+
+    /// Deletes HealthKit samples by UUID. Used to clean up our prior writes on
+    /// meal/scan edits. Failures are soft — caller marks pending_delete and retries.
+    @objc public func deleteSamples(_ call: CAPPluginCall) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            call.resolve(["deleted": 0, "failed": []])
+            return
+        }
+        guard let uuidStrings = call.getArray("uuids") as? [String] else {
+            call.reject("uuids array required")
+            return
+        }
+        if uuidStrings.isEmpty {
+            call.resolve(["deleted": 0, "failed": []])
+            return
+        }
+
+        let uuids = uuidStrings.compactMap { UUID(uuidString: $0) }
+        let predicate = NSPredicate(format: "%K IN %@", HKPredicateKeyPathUUID, uuids)
+
+        // We have to query each relevant type and delete matching objects — HK
+        // doesn't offer a type-agnostic deletion API.
+        let typesToSearch: [HKSampleType] = Self.allWritableTypesForDelete()
+        let group = DispatchGroup()
+        var deletedCount = 0
+        var failed: [String] = []
+        let lock = NSLock()
+
+        for type in typesToSearch {
+            group.enter()
+            let q = HKSampleQuery(sampleType: type, predicate: predicate,
+                                  limit: HKObjectQueryNoLimit, sortDescriptors: nil) { [weak self] _, found, err in
+                guard let self = self else { group.leave(); return }
+                if err != nil || (found?.isEmpty ?? true) { group.leave(); return }
+                self.healthStore.delete(found ?? []) { success, _ in
+                    lock.lock()
+                    if success {
+                        deletedCount += (found?.count ?? 0)
+                    } else {
+                        failed.append(contentsOf: (found ?? []).map { $0.uuid.uuidString })
+                    }
+                    lock.unlock()
+                    group.leave()
+                }
+            }
+            healthStore.execute(q)
+        }
+
+        group.notify(queue: .main) {
+            call.resolve(["deleted": deletedCount, "failed": failed])
+        }
+    }
+
     // MARK: - Helpers
 
-    private func startOfTodayMs() -> Double {
+    private func quantitySum(call: CAPPluginCall, identifier: HKQuantityTypeIdentifier, unit: HKUnit) {
+        guard HKHealthStore.isHealthDataAvailable(),
+              let type = HKQuantityType.quantityType(forIdentifier: identifier) else {
+            call.resolve(["value": 0])
+            return
+        }
+        let startMs = call.getDouble("startTime") ?? startOfTodayMs()
+        let endMs = call.getDouble("endTime") ?? Date().timeIntervalSince1970 * 1000
+        let startDate = Date(timeIntervalSince1970: startMs / 1000.0)
+        let endDate = Date(timeIntervalSince1970: endMs / 1000.0)
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
+        let q = HKStatisticsQuery(quantityType: type, quantitySamplePredicate: predicate,
+                                  options: .cumulativeSum) { _, result, _ in
+            let value = result?.sumQuantity()?.doubleValue(for: unit) ?? 0
+            call.resolve(["value": Int(value)])
+        }
+        healthStore.execute(q)
+    }
+
+    /// Group HKCategorySample[] into nights. A "night" is a contiguous group of
+    /// sleep/inBed samples with no gap >14h between them. Night key is the
+    /// calendar date of the last wake time.
+    private func groupSleepIntoNights(_ samples: [HKCategorySample]) -> [[String: Any]] {
+        guard !samples.isEmpty else { return [] }
+        let sorted = samples.sorted { $0.startDate < $1.startDate }
+
+        // Cluster samples by gap
+        var clusters: [[HKCategorySample]] = []
+        var current: [HKCategorySample] = []
+        var lastEnd: Date?
+        let clusterGap: TimeInterval = 14 * 3600
+        for s in sorted {
+            if let le = lastEnd, s.startDate.timeIntervalSince(le) > clusterGap {
+                if !current.isEmpty { clusters.append(current) }
+                current = []
+            }
+            current.append(s)
+            lastEnd = max(lastEnd ?? s.endDate, s.endDate)
+        }
+        if !current.isEmpty { clusters.append(current) }
+
         let cal = Calendar.current
-        let start = cal.startOfDay(for: Date())
-        return start.timeIntervalSince1970 * 1000
+        return clusters.map { cluster -> [String: Any] in
+            var asleep = 0.0, rem = 0.0, deep = 0.0, core = 0.0, awake = 0.0, inBed = 0.0
+            let start = cluster.first?.startDate ?? Date()
+            let end = cluster.last?.endDate ?? Date()
+            for s in cluster {
+                let mins = s.endDate.timeIntervalSince(s.startDate) / 60.0
+                if #available(iOS 16, *) {
+                    switch s.value {
+                    case HKCategoryValueSleepAnalysis.asleepREM.rawValue: rem += mins; asleep += mins
+                    case HKCategoryValueSleepAnalysis.asleepDeep.rawValue: deep += mins; asleep += mins
+                    case HKCategoryValueSleepAnalysis.asleepCore.rawValue: core += mins; asleep += mins
+                    case HKCategoryValueSleepAnalysis.asleepUnspecified.rawValue: asleep += mins
+                    case HKCategoryValueSleepAnalysis.awake.rawValue: awake += mins
+                    case HKCategoryValueSleepAnalysis.inBed.rawValue: inBed += mins
+                    default: break
+                    }
+                } else {
+                    // iOS 15 only had asleep / inBed / awake
+                    switch s.value {
+                    case HKCategoryValueSleepAnalysis.inBed.rawValue: inBed += mins
+                    case HKCategoryValueSleepAnalysis.awake.rawValue: awake += mins
+                    default: asleep += mins
+                    }
+                }
+            }
+            // inBed samples typically span the whole night and overlap with asleep
+            // samples from Watch. Keep them separate — caller can choose.
+            let wakeDate = Self.ymdString(end, calendar: cal)
+            return [
+                "date": wakeDate,
+                "start_at": start.timeIntervalSince1970 * 1000,
+                "end_at": end.timeIntervalSince1970 * 1000,
+                "asleep_min": Int(asleep),
+                "rem_min": Int(rem),
+                "deep_min": Int(deep),
+                "core_min": Int(core),
+                "awake_min": Int(awake),
+                "in_bed_min": Int(inBed)
+            ]
+        }
+    }
+
+    private func workoutToLegacyDict(_ w: HKWorkout) -> [String: Any] {
+        let durationMins = w.duration / 60.0
+        let calories = w.totalEnergyBurned?.doubleValue(for: .kilocalorie()) ?? 0
+        let distance = w.totalDistance?.doubleValue(for: .meter()) ?? 0
+        return [
+            "startTime": w.startDate.timeIntervalSince1970 * 1000,
+            "endTime": w.endDate.timeIntervalSince1970 * 1000,
+            "durationMinutes": Int(durationMins),
+            "activeCalories": Int(calories),
+            "distanceMeters": Int(distance),
+            "activityType": Self.activityTypeName(w.workoutActivityType),
+        ]
+    }
+
+    private func workoutToFullDict(_ w: HKWorkout) -> [String: Any] {
+        // Only include keys with real values. Capacitor's JSCore bridge does not
+        // safely serialize NSNull in nested dicts, so missing optionals are omitted
+        // entirely — the TS side treats missing as null.
+        var meta: [String: Any] = [:]
+        for (k, v) in w.metadata ?? [:] {
+            if let str = v as? String { meta[k] = str }
+            else if let num = v as? NSNumber { meta[k] = num }
+        }
+        let rebirthUuid = (meta["REBIRTH_WORKOUT_UUID"] as? String) ?? (meta[HKMetadataKeyExternalUUID] as? String)
+        var dict: [String: Any] = [
+            "hk_uuid": w.uuid.uuidString,
+            "activity_type": Self.activityTypeName(w.workoutActivityType),
+            "start_at": w.startDate.timeIntervalSince1970 * 1000,
+            "end_at": w.endDate.timeIntervalSince1970 * 1000,
+            "duration_s": Int(w.duration),
+            "source_name": w.sourceRevision.source.name,
+            "source_bundle_id": w.sourceRevision.source.bundleIdentifier,
+            "metadata_json": Self.jsonString(meta),
+        ]
+        if let energy = w.totalEnergyBurned?.doubleValue(for: .kilocalorie()) {
+            dict["total_energy_kcal"] = energy
+        }
+        if let distance = w.totalDistance?.doubleValue(for: .meter()) {
+            dict["total_distance_m"] = distance
+        }
+        if let r = rebirthUuid { dict["rebirth_workout_uuid"] = r }
+        return dict
+    }
+
+    // MARK: - Anchor codec
+
+    private static func encodeAnchor(_ anchor: HKQueryAnchor?) -> String {
+        guard let anchor = anchor else { return "" }
+        do {
+            let data = try NSKeyedArchiver.archivedData(withRootObject: anchor, requiringSecureCoding: true)
+            return data.base64EncodedString()
+        } catch {
+            return ""
+        }
+    }
+
+    private static func decodeAnchor(_ str: String?) -> HKQueryAnchor? {
+        guard let str = str, !str.isEmpty, let data = Data(base64Encoded: str) else { return nil }
+        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: data)
+    }
+
+    // MARK: - Metric spec
+
+    private struct MetricSpec {
+        let type: HKQuantityType
+        let unit: HKUnit
+        let options: HKStatisticsOptions
+    }
+
+    private static func metricSpec(_ metric: String) -> MetricSpec? {
+        switch metric {
+        case "steps":
+            guard let t = HKQuantityType.quantityType(forIdentifier: .stepCount) else { return nil }
+            return MetricSpec(type: t, unit: .count(), options: [.cumulativeSum])
+        case "active_energy":
+            guard let t = HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned) else { return nil }
+            return MetricSpec(type: t, unit: .kilocalorie(), options: [.cumulativeSum])
+        case "basal_energy":
+            guard let t = HKQuantityType.quantityType(forIdentifier: .basalEnergyBurned) else { return nil }
+            return MetricSpec(type: t, unit: .kilocalorie(), options: [.cumulativeSum])
+        case "exercise_minutes":
+            guard let t = HKQuantityType.quantityType(forIdentifier: .appleExerciseTime) else { return nil }
+            return MetricSpec(type: t, unit: .minute(), options: [.cumulativeSum])
+        case "heart_rate":
+            guard let t = HKQuantityType.quantityType(forIdentifier: .heartRate) else { return nil }
+            return MetricSpec(type: t, unit: HKUnit.count().unitDivided(by: .minute()),
+                              options: [.discreteAverage, .discreteMin, .discreteMax])
+        case "hrv":
+            guard let t = HKQuantityType.quantityType(forIdentifier: .heartRateVariabilitySDNN) else { return nil }
+            return MetricSpec(type: t, unit: .secondUnit(with: .milli),
+                              options: [.discreteAverage, .discreteMin, .discreteMax])
+        case "resting_hr":
+            guard let t = HKQuantityType.quantityType(forIdentifier: .restingHeartRate) else { return nil }
+            return MetricSpec(type: t, unit: HKUnit.count().unitDivided(by: .minute()),
+                              options: [.discreteAverage, .discreteMin, .discreteMax])
+        case "vo2_max":
+            guard let t = HKQuantityType.quantityType(forIdentifier: .vo2Max) else { return nil }
+            return MetricSpec(type: t,
+                              unit: HKUnit(from: "ml/kg*min"),
+                              options: [.discreteAverage, .discreteMin, .discreteMax])
+        default:
+            return nil
+        }
+    }
+
+    private static func primarySourceId(_ stats: HKStatistics) -> String {
+        let sources = stats.sources ?? []
+        return sources.first?.bundleIdentifier ?? ""
+    }
+
+    // MARK: - Permission type sets
+
+    /// All read + write types we request from HealthKit, bundled for requestAuthorization.
+    private static func allRequestedTypes() -> (read: Set<HKObjectType>, write: Set<HKSampleType>) {
+        var read: Set<HKObjectType> = []
+        var write: Set<HKSampleType> = []
+
+        // Reads
+        for id in [HKQuantityTypeIdentifier.stepCount, .activeEnergyBurned, .basalEnergyBurned,
+                   .heartRate, .heartRateVariabilitySDNN, .restingHeartRate,
+                   .vo2Max, .appleExerciseTime] {
+            if let t = HKQuantityType.quantityType(forIdentifier: id) {
+                read.insert(t)
+            }
+        }
+        if let t = HKCategoryType.categoryType(forIdentifier: .sleepAnalysis) {
+            read.insert(t)
+        }
+        read.insert(HKObjectType.workoutType())
+
+        // Writes
+        write.insert(HKObjectType.workoutType())
+        for id in [HKQuantityTypeIdentifier.activeEnergyBurned, .bodyMass, .bodyFatPercentage, .leanBodyMass,
+                   .dietaryEnergyConsumed, .dietaryProtein, .dietaryCarbohydrates, .dietaryFatTotal,
+                   .dietaryWater] {
+            if let t = HKQuantityType.quantityType(forIdentifier: id) {
+                write.insert(t)
+            }
+        }
+
+        return (read, write)
+    }
+
+    /// Writable types we may need to search for deletion. (Our own writeback samples.)
+    private static func allWritableTypesForDelete() -> [HKSampleType] {
+        var types: [HKSampleType] = []
+        types.append(HKObjectType.workoutType())
+        for id in [HKQuantityTypeIdentifier.bodyMass, .bodyFatPercentage, .leanBodyMass,
+                   .dietaryEnergyConsumed, .dietaryProtein, .dietaryCarbohydrates, .dietaryFatTotal,
+                   .dietaryWater, .activeEnergyBurned] {
+            if let t = HKQuantityType.quantityType(forIdentifier: id) {
+                types.append(t)
+            }
+        }
+        return types
+    }
+
+    private static func authStatusString(_ status: HKAuthorizationStatus) -> String {
+        switch status {
+        case .sharingAuthorized: return "granted"
+        case .sharingDenied: return "denied"
+        case .notDetermined: return "notDetermined"
+        @unknown default: return "notDetermined"
+        }
+    }
+
+    // MARK: - Misc
+
+    private func startOfTodayMs() -> Double {
+        Calendar.current.startOfDay(for: Date()).timeIntervalSince1970 * 1000
     }
 
     private func sevenDaysAgoMs() -> Double {
-        let date = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
-        return date.timeIntervalSince1970 * 1000
+        (Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()).timeIntervalSince1970 * 1000
     }
 
-    private func activityTypeName(_ type: HKWorkoutActivityType) -> String {
+    private static func ymdString(_ date: Date, calendar: Calendar) -> String {
+        let comps = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", comps.year ?? 0, comps.month ?? 0, comps.day ?? 0)
+    }
+
+    private static func jsonString(_ obj: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: obj),
+              let str = String(data: data, encoding: .utf8) else { return "{}" }
+        return str
+    }
+
+    private static func activityTypeName(_ type: HKWorkoutActivityType) -> String {
         switch type {
         case .traditionalStrengthTraining: return "Strength Training"
         case .functionalStrengthTraining: return "Functional Strength"
@@ -253,6 +910,8 @@ public class HealthKitPlugin: CAPPlugin, CAPBridgedPlugin {
         case .crossTraining: return "Cross Training"
         case .elliptical: return "Elliptical"
         case .rowing: return "Rowing"
+        case .mixedCardio: return "Mixed Cardio"
+        case .coreTraining: return "Core Training"
         default: return "Workout"
         }
     }

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -79,5 +79,13 @@
 		<string>fetch</string>
 	</array>
 
+	<!-- HealthKit — read/write usage descriptions shown in the iOS permission sheet.
+	     Required for any HealthKit-capable build; App Store Review rejects builds that
+	     request HealthKit access without these keys present. -->
+	<key>NSHealthShareUsageDescription</key>
+	<string>Rebirth reads your workouts, heart rate, HRV, resting heart rate, VO2 max, sleep, and activity so your AI coach can tailor training and recovery guidance to your real data.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Rebirth writes your completed workouts, logged meals, and InBody scan results to Health so they count toward your rings and appear alongside data from your other apps and devices.</string>
+
 </dict>
 </plist>

--- a/scripts/cap-post-sync.mjs
+++ b/scripts/cap-post-sync.mjs
@@ -5,14 +5,14 @@
  * 1. Bump `ios/App/CapApp-SPM/Package.swift` swift-tools-version 5.9 → 6.0 so
  *    `.iOS(.v18)` resolves. Capacitor CLI writes 5.9 regardless of our config.
  *
- * 2. Add our local Swift plugins (RestTimerPlugin, InspoBurstPlugin) to
- *    `ios/App/App/capacitor.config.json` `packageClassList`. Capacitor 8 only
- *    auto-registers plugins discovered via SPM dependencies; loose .swift
- *    files in the App target are not discovered. Adding the class names here
- *    makes Capacitor instantiate them at bridge init (before JS queries the
- *    bridge for method signatures), so `registerPlugin('RestTimer', …)` on
- *    the JS side resolves to the native implementation instead of caching
- *    "plugin is not implemented on ios".
+ * 2. Add our local Swift plugins (RestTimerPlugin, InspoBurstPlugin,
+ *    HealthKitPlugin, GeofencePlugin) to `ios/App/App/capacitor.config.json`
+ *    `packageClassList`. Capacitor 8 only auto-registers plugins discovered
+ *    via SPM dependencies; loose .swift files in the App target are not
+ *    discovered. Adding the class names here makes Capacitor instantiate
+ *    them at bridge init (before JS queries the bridge for method signatures),
+ *    so `registerPlugin('HealthKit', …)` on the JS side resolves to the
+ *    native implementation instead of caching "plugin is not implemented on ios".
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 
@@ -27,7 +27,7 @@ if (swiftPkg.includes('swift-tools-version: 5.9')) {
 // --- (2) packageClassList ---
 const configPath = 'ios/App/App/capacitor.config.json';
 const config = JSON.parse(readFileSync(configPath, 'utf8'));
-const LOCAL_PLUGINS = ['RestTimerPlugin', 'InspoBurstPlugin'];
+const LOCAL_PLUGINS = ['RestTimerPlugin', 'InspoBurstPlugin', 'HealthKitPlugin', 'GeofencePlugin'];
 config.packageClassList = Array.isArray(config.packageClassList) ? config.packageClassList : [];
 let added = 0;
 for (const name of LOCAL_PLUGINS) {

--- a/src/app/api/healthkit/pending-mirror/route.ts
+++ b/src/app/api/healthkit/pending-mirror/route.ts
@@ -1,0 +1,81 @@
+/**
+ * Returns nutrition_logs and inbody_scans that haven't been mirrored to HealthKit
+ * yet — either never written, or edited since last writeback. Client picks these
+ * up during foreground sync and calls native saveNutrition / saveBodyComposition.
+ *
+ * "Needs mirror" = (no writeback row for source_uuid) OR (max writeback.written_at
+ * < source.updated_at for the source row).
+ *
+ * Scope: last 30 days of nutrition_logs + all inbody_scans (they're sparse; <100
+ * rows total). Keeps initial mirror bounded.
+ */
+
+import { NextResponse } from 'next/server';
+import { query } from '@/db/db';
+
+interface NutritionMirrorRow {
+  uuid: string;
+  logged_at: string;
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  hydration_ml: number | null;
+}
+
+interface InbodyMirrorRow {
+  uuid: string;
+  scanned_at: string;
+  weight_kg: number | null;
+  pbf_pct: number | null;
+  smm_kg: number | null;   // skeletal muscle mass ≈ usable proxy for "lean mass" input
+}
+
+export async function GET() {
+  const nutrition = await query<NutritionMirrorRow>(
+    `SELECT n.uuid,
+            to_char(n.logged_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS logged_at,
+            n.calories,
+            n.protein_g,
+            n.carbs_g,
+            n.fat_g,
+            NULL::numeric AS hydration_ml
+     FROM nutrition_logs n
+     LEFT JOIN (
+       SELECT source_uuid, MAX(written_at) AS last_written
+       FROM healthkit_writeback
+       WHERE source_kind = 'meal'
+       GROUP BY source_uuid
+     ) w ON w.source_uuid = n.uuid
+     WHERE n.logged_at >= NOW() - interval '30 days'
+       AND (w.last_written IS NULL
+            OR w.last_written < n.logged_at)
+       -- Only rows with at least one macro to mirror
+       AND (n.calories IS NOT NULL
+            OR n.protein_g IS NOT NULL
+            OR n.carbs_g IS NOT NULL
+            OR n.fat_g IS NOT NULL)
+     ORDER BY n.logged_at DESC
+     LIMIT 200`
+  );
+
+  const inbody = await query<InbodyMirrorRow>(
+    `SELECT i.uuid,
+            to_char(i.scanned_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS scanned_at,
+            i.weight_kg,
+            i.pbf_pct,
+            i.smm_kg
+     FROM inbody_scans i
+     LEFT JOIN (
+       SELECT source_uuid, MAX(written_at) AS last_written
+       FROM healthkit_writeback
+       WHERE source_kind = 'inbody'
+       GROUP BY source_uuid
+     ) w ON w.source_uuid = i.uuid
+     WHERE w.last_written IS NULL
+        OR w.last_written < i.updated_at
+     ORDER BY i.scanned_at DESC`
+  );
+
+  return NextResponse.json({ nutrition, inbody });
+}

--- a/src/app/api/healthkit/sync/route.ts
+++ b/src/app/api/healthkit/sync/route.ts
@@ -1,0 +1,295 @@
+/**
+ * HealthKit sync endpoint.
+ *
+ * Single POST handler that ingests everything the iOS client fetched on a
+ * foreground sync pass — daily quantity aggregates, sleep nights, workouts —
+ * in one transaction, and returns updated sync state. Reads return sync state
+ * without writes so the client can prime its per-metric window/anchor bookkeeping.
+ *
+ * Workout dedup runs here (server-side) so the rule is consistent across
+ * clients and the client doesn't need workouts.uuid lookups.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { query, queryOne, transaction } from '@/db/db';
+
+interface DailyRow {
+  metric: string;
+  date: string;
+  value_min?: number | null;
+  value_max?: number | null;
+  value_avg?: number | null;
+  value_sum?: number | null;
+  count?: number | null;
+  source_primary?: string | null;
+}
+
+interface SleepNight {
+  date: string;
+  start_at: number;
+  end_at: number;
+  asleep_min: number;
+  rem_min: number;
+  deep_min: number;
+  core_min: number;
+  awake_min: number;
+  in_bed_min: number;
+}
+
+interface FullHKWorkout {
+  hk_uuid: string;
+  activity_type: string;
+  start_at: number;
+  end_at: number;
+  duration_s: number;
+  total_energy_kcal?: number | null;
+  total_distance_m?: number | null;
+  source_name?: string;
+  source_bundle_id?: string;
+  metadata_json?: string;
+  rebirth_workout_uuid?: string;
+}
+
+interface SyncStateUpdate {
+  metric: string;
+  last_window_end?: string | null;   // ISO
+  last_anchor?: string | null;       // base64
+  last_error?: string | null;
+}
+
+interface SyncBody {
+  daily?: DailyRow[];
+  sleep?: SleepNight[];
+  workouts?: FullHKWorkout[];
+  deleted_workouts?: string[];       // HK UUIDs that were deleted since last anchor
+  state_updates?: SyncStateUpdate[];
+}
+
+// ── GET: return sync state for all metrics ──────────────────────────────────
+
+export async function GET() {
+  const rows = await query<{
+    metric: string;
+    last_anchor: Buffer | null;
+    last_window_end: string | null;
+    last_sync_at: string | null;
+    last_successful_sync_at: string | null;
+    last_error: string | null;
+    last_error_at: string | null;
+  }>(`SELECT metric, last_anchor, last_window_end, last_sync_at,
+             last_successful_sync_at, last_error, last_error_at
+      FROM healthkit_sync_state`);
+
+  const byMetric = Object.fromEntries(rows.map(r => [r.metric, {
+    // Surface base64 so the iOS client can round-trip. Postgres BYTEA comes
+    // out as a Node Buffer via the pg driver.
+    last_anchor: r.last_anchor ? r.last_anchor.toString('base64') : null,
+    last_window_end: r.last_window_end,
+    last_sync_at: r.last_sync_at,
+    last_successful_sync_at: r.last_successful_sync_at,
+    last_error: r.last_error,
+    last_error_at: r.last_error_at,
+  }]));
+
+  return NextResponse.json({ state: byMetric });
+}
+
+// ── POST: ingest sync payload ───────────────────────────────────────────────
+
+export async function POST(request: NextRequest) {
+  let body: SyncBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const daily = body.daily ?? [];
+  const sleep = body.sleep ?? [];
+  const workouts = body.workouts ?? [];
+  const deletedWorkoutUuids = body.deleted_workouts ?? [];
+  const stateUpdates = body.state_updates ?? [];
+
+  // ── Upsert daily aggregates ───────────────────────────────────────────────
+  const dailyStatements = daily.map((r) => ({
+    text: `INSERT INTO healthkit_daily
+             (metric, date, value_min, value_max, value_avg, value_sum, count, source_primary, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+           ON CONFLICT (metric, date) DO UPDATE SET
+             value_min = EXCLUDED.value_min,
+             value_max = EXCLUDED.value_max,
+             value_avg = EXCLUDED.value_avg,
+             value_sum = EXCLUDED.value_sum,
+             count = EXCLUDED.count,
+             source_primary = EXCLUDED.source_primary,
+             updated_at = NOW()`,
+    params: [
+      r.metric, r.date,
+      r.value_min ?? null, r.value_max ?? null,
+      r.value_avg ?? null, r.value_sum ?? null,
+      r.count ?? null, r.source_primary ?? null,
+    ],
+  }));
+
+  // ── Sleep nights → daily rows (one per stage) ─────────────────────────────
+  // Each sleep night produces 6 daily rows, keyed to wake date.
+  const sleepDailyRows: DailyRow[] = [];
+  for (const n of sleep) {
+    sleepDailyRows.push({ metric: 'sleep_asleep', date: n.date, value_sum: n.asleep_min });
+    sleepDailyRows.push({ metric: 'sleep_rem', date: n.date, value_sum: n.rem_min });
+    sleepDailyRows.push({ metric: 'sleep_deep', date: n.date, value_sum: n.deep_min });
+    sleepDailyRows.push({ metric: 'sleep_core', date: n.date, value_sum: n.core_min });
+    sleepDailyRows.push({ metric: 'sleep_awake', date: n.date, value_sum: n.awake_min });
+    sleepDailyRows.push({ metric: 'sleep_inbed', date: n.date, value_sum: n.in_bed_min });
+  }
+  const sleepStatements = sleepDailyRows.map((r) => ({
+    text: `INSERT INTO healthkit_daily (metric, date, value_sum, count, updated_at)
+           VALUES ($1, $2, $3, 1, NOW())
+           ON CONFLICT (metric, date) DO UPDATE SET
+             value_sum = EXCLUDED.value_sum, count = 1, updated_at = NOW()`,
+    params: [r.metric, r.date, r.value_sum ?? null],
+  }));
+
+  // ── Workouts: upsert with dedup resolution ────────────────────────────────
+  const workoutStatements: Array<{ text: string; params?: unknown[] }> = [];
+
+  // Delete rows that HealthKit reports as deleted
+  if (deletedWorkoutUuids.length > 0) {
+    workoutStatements.push({
+      text: `DELETE FROM healthkit_workouts WHERE hk_uuid = ANY($1)`,
+      params: [deletedWorkoutUuids],
+    });
+  }
+
+  // For each incoming HK workout, resolve dedup server-side
+  for (const w of workouts) {
+    const startMs = w.start_at;
+    const endMs = w.end_at;
+    const startIso = new Date(startMs).toISOString();
+    const endIso = new Date(endMs).toISOString();
+
+    // Resolve workout_uuid + source via dedup rules:
+    // 1. If metadata has REBIRTH_WORKOUT_UUID → direct link, 'user_logged'
+    // 2. Else fuzzy match: activity_type + start within ±60s of a Rebirth workout
+    //    and duration within 10% → 'matched'
+    // 3. Else → 'hk_only'
+    let workoutUuid: string | null = null;
+    let source: 'user_logged' | 'matched' | 'hk_only' = 'hk_only';
+
+    if (w.rebirth_workout_uuid) {
+      const existing = await queryOne<{ uuid: string }>(
+        `SELECT uuid FROM workouts WHERE uuid = $1`,
+        [w.rebirth_workout_uuid]
+      );
+      if (existing) {
+        workoutUuid = existing.uuid;
+        source = 'user_logged';
+      }
+    }
+
+    if (workoutUuid == null) {
+      // Fuzzy match — only for "Strength Training"-like types that we log
+      const fuzzyMatch = await queryOne<{ uuid: string; start_time: string; end_time: string | null }>(
+        `SELECT uuid, start_time, end_time
+         FROM workouts
+         WHERE start_time BETWEEN $1::timestamptz - interval '60 seconds'
+                              AND $1::timestamptz + interval '60 seconds'
+           AND is_current = false
+         ORDER BY ABS(EXTRACT(EPOCH FROM start_time) - EXTRACT(EPOCH FROM $1::timestamptz))
+         LIMIT 1`,
+        [startIso]
+      );
+      if (fuzzyMatch && fuzzyMatch.end_time) {
+        const dbDur = (new Date(fuzzyMatch.end_time).getTime() - new Date(fuzzyMatch.start_time).getTime()) / 1000;
+        const hkDur = w.duration_s;
+        if (dbDur > 0 && Math.abs(hkDur - dbDur) / dbDur <= 0.1) {
+          workoutUuid = fuzzyMatch.uuid;
+          source = 'matched';
+        }
+      }
+    }
+
+    workoutStatements.push({
+      text: `INSERT INTO healthkit_workouts
+               (hk_uuid, activity_type, start_at, end_at, duration_s,
+                total_energy_kcal, total_distance_m,
+                source_name, source_bundle_id, metadata_json,
+                workout_uuid, source, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12, NOW(), NOW())
+             ON CONFLICT (hk_uuid) DO UPDATE SET
+               activity_type = EXCLUDED.activity_type,
+               start_at = EXCLUDED.start_at,
+               end_at = EXCLUDED.end_at,
+               duration_s = EXCLUDED.duration_s,
+               total_energy_kcal = EXCLUDED.total_energy_kcal,
+               total_distance_m = EXCLUDED.total_distance_m,
+               source_name = EXCLUDED.source_name,
+               source_bundle_id = EXCLUDED.source_bundle_id,
+               metadata_json = EXCLUDED.metadata_json,
+               workout_uuid = COALESCE(healthkit_workouts.workout_uuid, EXCLUDED.workout_uuid),
+               source = CASE
+                 WHEN healthkit_workouts.source = 'user_logged' THEN 'user_logged'
+                 ELSE EXCLUDED.source
+               END,
+               updated_at = NOW()`,
+      params: [
+        w.hk_uuid, w.activity_type, startIso, endIso, w.duration_s,
+        w.total_energy_kcal ?? null, w.total_distance_m ?? null,
+        w.source_name ?? null, w.source_bundle_id ?? null,
+        w.metadata_json ?? '{}',
+        workoutUuid, source,
+      ],
+    });
+  }
+
+  // ── Sync-state upserts ────────────────────────────────────────────────────
+  const stateStatements = stateUpdates.map((s) => ({
+    text: `INSERT INTO healthkit_sync_state
+             (metric, last_anchor, last_window_end, last_sync_at,
+              last_successful_sync_at, last_error, last_error_at)
+           VALUES ($1,
+                   CASE WHEN $2::text IS NULL THEN NULL
+                        ELSE decode($2, 'base64') END,
+                   $3::timestamptz, NOW(),
+                   CASE WHEN $4::text IS NULL THEN NOW() ELSE NULL END,
+                   $4, CASE WHEN $4::text IS NULL THEN NULL ELSE NOW() END)
+           ON CONFLICT (metric) DO UPDATE SET
+             last_anchor = COALESCE(
+               CASE WHEN EXCLUDED.last_anchor IS NULL THEN healthkit_sync_state.last_anchor
+                    ELSE EXCLUDED.last_anchor END,
+               healthkit_sync_state.last_anchor
+             ),
+             last_window_end = COALESCE(EXCLUDED.last_window_end, healthkit_sync_state.last_window_end),
+             last_sync_at = NOW(),
+             last_successful_sync_at = CASE WHEN EXCLUDED.last_error IS NULL
+                                            THEN NOW()
+                                            ELSE healthkit_sync_state.last_successful_sync_at END,
+             last_error = EXCLUDED.last_error,
+             last_error_at = CASE WHEN EXCLUDED.last_error IS NULL THEN NULL ELSE NOW() END`,
+    params: [
+      s.metric,
+      s.last_anchor ?? null,
+      s.last_window_end ?? null,
+      s.last_error ?? null,
+    ],
+  }));
+
+  const allStatements = [
+    ...dailyStatements,
+    ...sleepStatements,
+    ...workoutStatements,
+    ...stateStatements,
+  ];
+
+  if (allStatements.length > 0) {
+    await transaction(allStatements);
+  }
+
+  return NextResponse.json({
+    daily_upserted: dailyStatements.length,
+    sleep_upserted: sleepStatements.length,
+    workouts_upserted: workouts.length,
+    workouts_deleted: deletedWorkoutUuids.length,
+    state_updates: stateUpdates.length,
+  });
+}

--- a/src/app/api/healthkit/writeback/route.ts
+++ b/src/app/api/healthkit/writeback/route.ts
@@ -1,0 +1,98 @@
+/**
+ * HealthKit writeback tracking.
+ *
+ * Records the HK sample UUIDs Rebirth authored (nutrition meals, InBody scans)
+ * so that subsequent edits/deletes can clean up old HK samples before writing
+ * fresh ones. Without this we'd double-count in Apple Health every time the
+ * user edits a meal.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { query, transaction } from '@/db/db';
+
+interface WritebackSample {
+  hk_type: string;
+  hk_uuid: string;
+}
+
+interface RecordBody {
+  source_kind: 'meal' | 'inbody' | 'workout';
+  source_uuid: string;
+  samples: WritebackSample[];
+}
+
+// GET ?source_kind=meal&source_uuid=...
+// Returns existing writeback rows for a source (used to find HK UUIDs to delete
+// before writing replacements on an edit).
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const kind = searchParams.get('source_kind');
+  const uuid = searchParams.get('source_uuid');
+
+  if (!kind || !uuid) {
+    return NextResponse.json({ error: 'source_kind and source_uuid required' }, { status: 400 });
+  }
+  if (!['meal', 'inbody', 'workout'].includes(kind)) {
+    return NextResponse.json({ error: 'invalid source_kind' }, { status: 400 });
+  }
+
+  const rows = await query<{ hk_type: string; hk_uuid: string; pending_delete: boolean }>(
+    `SELECT hk_type, hk_uuid, pending_delete
+       FROM healthkit_writeback
+       WHERE source_kind = $1 AND source_uuid = $2`,
+    [kind, uuid]
+  );
+
+  return NextResponse.json({ samples: rows });
+}
+
+// POST: record writeback rows after a successful native save. On conflict
+// (same source_kind/source_uuid/hk_type) we overwrite with the new hk_uuid,
+// which is what we want after an edit cycle (delete-old → save-new → record-new).
+export async function POST(request: NextRequest) {
+  let body: RecordBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  if (!body.source_kind || !body.source_uuid || !Array.isArray(body.samples)) {
+    return NextResponse.json({ error: 'source_kind, source_uuid, samples[] required' }, { status: 400 });
+  }
+
+  const statements = body.samples.map(s => ({
+    text: `INSERT INTO healthkit_writeback
+             (source_kind, source_uuid, hk_type, hk_uuid, pending_delete, written_at)
+           VALUES ($1, $2, $3, $4, FALSE, NOW())
+           ON CONFLICT (source_kind, source_uuid, hk_type) DO UPDATE SET
+             hk_uuid = EXCLUDED.hk_uuid,
+             pending_delete = FALSE,
+             written_at = NOW()`,
+    params: [body.source_kind, body.source_uuid, s.hk_type, s.hk_uuid],
+  }));
+
+  if (statements.length > 0) {
+    await transaction(statements);
+  }
+
+  return NextResponse.json({ recorded: statements.length });
+}
+
+// DELETE ?source_kind=meal&source_uuid=...
+// Drops writeback rows for a source (after a successful HK delete).
+export async function DELETE(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const kind = searchParams.get('source_kind');
+  const uuid = searchParams.get('source_uuid');
+
+  if (!kind || !uuid) {
+    return NextResponse.json({ error: 'source_kind and source_uuid required' }, { status: 400 });
+  }
+
+  await query(
+    `DELETE FROM healthkit_writeback WHERE source_kind = $1 AND source_uuid = $2`,
+    [kind, uuid]
+  );
+  return NextResponse.json({ deleted: true });
+}

--- a/src/app/api/sync/pull/route.test.ts
+++ b/src/app/api/sync/pull/route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/db/db', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '@/db/db';
+import { GET } from './route';
+
+type QueryMock = ReturnType<typeof vi.fn>;
+const queryMock = query as unknown as QueryMock;
+
+// The pull route runs five queries in a Promise.all: workouts,
+// workout_exercises, workout_sets, bodyweight_logs, exercises (in that order).
+// Each test below stages the results by call order.
+function stageResults(rows: Record<string, unknown>[][]) {
+  queryMock.mockReset();
+  for (const r of rows) queryMock.mockResolvedValueOnce(r);
+}
+
+const nowIso = '2026-04-20T00:00:00.000Z';
+
+describe('GET /api/sync/pull — catalog bundling', () => {
+  beforeEach(() => queryMock.mockReset());
+
+  it('full pull returns an exercises array', async () => {
+    stageResults([
+      [], // workouts
+      [], // workout_exercises
+      [], // workout_sets
+      [], // bodyweight_logs
+      [
+        {
+          uuid: 'EX-UPPER-CASE',
+          everkinetic_id: 1,
+          title: 'Bench Press',
+          alias: [],
+          description: null,
+          primary_muscles: ['chest'],
+          secondary_muscles: [],
+          equipment: ['barbell'],
+          steps: [],
+          tips: [],
+          is_custom: false,
+          is_hidden: false,
+          movement_pattern: 'horizontal_push',
+          updated_at: nowIso,
+        },
+      ],
+    ]);
+
+    const res = await GET(new Request('http://localhost/api/sync/pull'));
+    const body = await res.json();
+
+    expect(body.exercises).toHaveLength(1);
+    // Server MUST lowercase the uuid to match client lookup normalization.
+    expect(body.exercises[0].uuid).toBe('ex-upper-case');
+    expect(body.exercises[0].title).toBe('Bench Press');
+    expect(body.exercises[0].movement_pattern).toBe('horizontal_push');
+
+    const callSqls = queryMock.mock.calls.map(c => c[0] as string);
+    expect(callSqls.some(s => s.includes('FROM exercises'))).toBe(true);
+    expect(callSqls.some(s => s.includes('is_hidden = false'))).toBe(true);
+  });
+
+  it('incremental pull filters exercises by updated_at > since', async () => {
+    stageResults([[], [], [], [], []]);
+
+    const since = '2026-04-10T00:00:00.000Z';
+    await GET(new Request(`http://localhost/api/sync/pull?since=${encodeURIComponent(since)}`));
+
+    const calls = queryMock.mock.calls;
+    const exercisesCall = calls.find(c => (c[0] as string).includes('FROM exercises'));
+    expect(exercisesCall, 'exercises query should be run on incremental pull too').toBeDefined();
+    expect(exercisesCall![0]).toMatch(/updated_at > \$1/);
+    expect(exercisesCall![1]).toEqual([since]);
+  });
+
+  it('lowercases exercise_uuid in workout_exercises too (regression: this was the recurring Unknown Exercise root cause)', async () => {
+    stageResults([
+      [],
+      [
+        {
+          uuid: 'we-1',
+          workout_uuid: 'w-1',
+          exercise_uuid: 'ABCDEF12-3456-7890-ABCD-EF1234567890',
+          comment: null,
+          order_index: 0,
+          updated_at: nowIso,
+        },
+      ],
+      [],
+      [],
+      [],
+    ]);
+
+    const res = await GET(new Request('http://localhost/api/sync/pull'));
+    const body = await res.json();
+    expect(body.workout_exercises[0].exercise_uuid).toBe('abcdef12-3456-7890-abcd-ef1234567890');
+  });
+});

--- a/src/app/api/sync/pull/route.ts
+++ b/src/app/api/sync/pull/route.ts
@@ -9,12 +9,15 @@ export async function GET(req: Request) {
     const pulledAt = new Date().toISOString();
 
     if (!since) {
-      // Full pull — return everything (initial sync)
-      const [workouts, workout_exercises, workout_sets, bodyweight_logs] = await Promise.all([
+      // Full pull — return everything (initial sync). Exercises ship in the same
+      // envelope so the local catalog is always consistent with the exercise_uuids
+      // referenced by workout_exercises — no independent hydration window.
+      const [workouts, workout_exercises, workout_sets, bodyweight_logs, exercises] = await Promise.all([
         query<Record<string, unknown>>('SELECT * FROM workouts ORDER BY start_time DESC LIMIT 200'),
         query<Record<string, unknown>>('SELECT * FROM workout_exercises'),
         query<Record<string, unknown>>('SELECT * FROM workout_sets'),
         query<Record<string, unknown>>('SELECT * FROM bodyweight_logs ORDER BY logged_at DESC LIMIT 500'),
+        query<Record<string, unknown>>('SELECT * FROM exercises WHERE is_hidden = false'),
       ]);
 
       return NextResponse.json({
@@ -22,17 +25,19 @@ export async function GET(req: Request) {
         workout_exercises: workout_exercises.map(mapWorkoutExercise),
         workout_sets: workout_sets.map(mapWorkoutSet),
         bodyweight_logs: bodyweight_logs.map(mapBodyweightLog),
+        exercises: exercises.map(mapExercise),
         deleted: { workouts: [], workout_exercises: [], workout_sets: [], bodyweight_logs: [] },
         pulled_at: pulledAt,
       });
     }
 
     // Incremental pull — only rows updated since `since`
-    const [workouts, workout_exercises, workout_sets, bodyweight_logs] = await Promise.all([
+    const [workouts, workout_exercises, workout_sets, bodyweight_logs, exercises] = await Promise.all([
       query<Record<string, unknown>>('SELECT * FROM workouts WHERE updated_at > $1', [since]),
       query<Record<string, unknown>>('SELECT * FROM workout_exercises WHERE updated_at > $1', [since]),
       query<Record<string, unknown>>('SELECT * FROM workout_sets WHERE updated_at > $1', [since]),
       query<Record<string, unknown>>('SELECT * FROM bodyweight_logs WHERE updated_at > $1', [since]),
+      query<Record<string, unknown>>('SELECT * FROM exercises WHERE is_hidden = false AND updated_at > $1', [since]),
     ]);
 
     return NextResponse.json({
@@ -40,6 +45,7 @@ export async function GET(req: Request) {
       workout_exercises: workout_exercises.map(mapWorkoutExercise),
       workout_sets: workout_sets.map(mapWorkoutSet),
       bodyweight_logs: bodyweight_logs.map(mapBodyweightLog),
+      exercises: exercises.map(mapExercise),
       // Hard-deletes are tracked via push; no server-side soft-delete tracking yet
       deleted: { workouts: [], workout_exercises: [], workout_sets: [], bodyweight_logs: [] },
       pulled_at: pulledAt,
@@ -109,5 +115,27 @@ function mapBodyweightLog(r: Record<string, unknown>) {
     _synced: true,
     _updated_at: r.updated_at ? new Date(r.updated_at as string).getTime() : Date.now(),
     _deleted: false,
+  };
+}
+
+// Shape must match LocalExercise in src/db/local.ts. uuid is lowercased so client
+// lookups (which lowercase too) can never miss on case.
+function mapExercise(r: Record<string, unknown>) {
+  const parseJsonOrArray = (v: unknown, fallback: unknown[] = []): unknown[] =>
+    Array.isArray(v) ? v : JSON.parse((v as string) || '[]') || fallback;
+  return {
+    uuid: (r.uuid as string).toLowerCase(),
+    everkinetic_id: r.everkinetic_id as number,
+    title: r.title as string,
+    alias: parseJsonOrArray(r.alias) as string[],
+    description: (r.description as string | null) ?? null,
+    primary_muscles: parseJsonOrArray(r.primary_muscles) as string[],
+    secondary_muscles: parseJsonOrArray(r.secondary_muscles) as string[],
+    equipment: parseJsonOrArray(r.equipment) as string[],
+    steps: parseJsonOrArray(r.steps) as string[],
+    tips: parseJsonOrArray(r.tips) as string[],
+    is_custom: Boolean(r.is_custom),
+    is_hidden: Boolean(r.is_hidden),
+    movement_pattern: (r.movement_pattern as string | null) ?? null,
   };
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useState, useRef, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import { markScheduleTap } from '@/lib/workout-schedule';
+import { werePermissionsRequested } from '@/features/health/healthService';
+import { runForegroundSync } from '@/features/health/healthSync';
 
 function makeQueryClient() {
   return new QueryClient({
@@ -48,12 +51,50 @@ function NotificationRouter() {
   return null;
 }
 
+// Kicks off a HealthKit foreground sync on app launch + on app resume, if the
+// user has previously connected HealthKit. Rate-limited to once every 2 minutes
+// to avoid thrashing when iOS rapid-fires appStateChange events.
+const HEALTHKIT_SYNC_MIN_INTERVAL_MS = 2 * 60 * 1000;
+
+function HealthKitResumeSync() {
+  const lastSyncAt = useRef(0);
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+
+    const trigger = () => {
+      // Skip sync on boot if we've never connected — the Settings-side probe
+      // will discover the real state via server lookup if localStorage was wiped.
+      if (!werePermissionsRequested()) return;
+      const now = Date.now();
+      if (now - lastSyncAt.current < HEALTHKIT_SYNC_MIN_INTERVAL_MS) return;
+      lastSyncAt.current = now;
+      runForegroundSync().catch(() => undefined);
+    };
+
+    // Initial on mount
+    trigger();
+
+    let cleanup: (() => void) | undefined;
+    App.addListener('appStateChange', ({ isActive }) => {
+      if (isActive) trigger();
+    }).then(handle => {
+      cleanup = () => handle.remove();
+    });
+
+    return () => cleanup?.();
+  }, []);
+
+  return null;
+}
+
 export function AppProviders({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => makeQueryClient());
 
   return (
     <QueryClientProvider client={queryClient}>
       <NotificationRouter />
+      <HealthKitResumeSync />
       {children}
       {process.env.NODE_ENV === 'development' ? (
         <ReactQueryDevtools buttonPosition="bottom-left" />

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -41,6 +41,7 @@ import {
   onHomeArrival,
 } from '@/lib/geofence';
 import { GeofenceOnboarding } from '@/components/GeofenceOnboarding';
+import { HealthKitSettings } from '@/components/HealthKitSettings';
 
 const REST_TIMES = [30, 60, 90, 120, 150, 180, 210, 240, 300];
 
@@ -789,6 +790,9 @@ export default function SettingsPage() {
             )}
           </div>
         )}
+
+        {/* ── Apple Health ────────────────────────────── */}
+        <HealthKitSettings />
 
         {/* ── Data ────────────────────────────────────── */}
         <div>

--- a/src/components/HealthKitSettings.tsx
+++ b/src/components/HealthKitSettings.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { App } from '@capacitor/app';
+import { ExternalLink, RefreshCw, HeartPulse } from 'lucide-react';
+import { HealthKit } from '@/lib/healthkit';
+import { markPermissionsRequested } from '@/features/health/healthService';
+import {
+  connectHealthKit,
+  runForegroundSync,
+  type SyncResult,
+} from '@/features/health/healthSync';
+import { apiBase } from '@/lib/api/client';
+
+// Coarse status — iOS hides per-type read auth, so pretending we know more
+// than "unavailable | not-connected | connected | error" is false precision.
+type Status = 'unavailable' | 'not-connected' | 'connected' | 'syncing' | 'error';
+
+function formatAgo(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return 'just now';
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins} min ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+export function HealthKitSettings() {
+  const [status, setStatus] = useState<Status>('not-connected');
+  const [lastSyncAt, setLastSyncAt] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [consecutiveErrors, setConsecutiveErrors] = useState(0);
+
+  const applySyncResult = useCallback((result: SyncResult) => {
+    if (result.ok) {
+      setStatus('connected');
+      setLastSyncAt(new Date().toISOString());
+      setErrorMessage(null);
+      setConsecutiveErrors(0);
+    } else if (result.reason === 'unavailable') {
+      setStatus('unavailable');
+    } else if (result.reason === 'not_requested' || result.reason === 'revoked') {
+      setStatus('not-connected');
+    } else {
+      setStatus(prev => (prev === 'connected' ? 'connected' : 'error'));
+      setErrorMessage(result.reason ?? 'unknown error');
+      setConsecutiveErrors(n => n + 1);
+    }
+  }, []);
+
+  const probeStatus = useCallback(async () => {
+    try {
+      const { available } = await HealthKit.isAvailable();
+      if (!available) {
+        setStatus('unavailable');
+        return;
+      }
+
+      // Server state is truth — if any metric has ever successfully synced,
+      // we've previously connected. localStorage is too fragile (can be cleared
+      // on app reinstall or when the webview cache is purged).
+      let serverSaysConnected = false;
+      let serverLastSync: string | null = null;
+      try {
+        const res = await fetch(`${apiBase()}/api/healthkit/sync`);
+        if (res.ok) {
+          const { state } = (await res.json()) as { state: Record<string, { last_successful_sync_at: string | null }> };
+          for (const s of Object.values(state ?? {})) {
+            if (s.last_successful_sync_at) {
+              serverSaysConnected = true;
+              if (!serverLastSync || s.last_successful_sync_at > serverLastSync) {
+                serverLastSync = s.last_successful_sync_at;
+              }
+            }
+          }
+        }
+      } catch {
+        // Network unavailable — fall through to native sync attempt
+      }
+
+      if (serverSaysConnected) {
+        // Forward-migrate the localStorage flag so old call sites work
+        markPermissionsRequested();
+        setLastSyncAt(serverLastSync);
+        // Kick off a fresh sync in the background; don't block the UI
+        setStatus('connected');
+        runForegroundSync().then(applySyncResult).catch(() => undefined);
+        return;
+      }
+
+      // No server record → either never connected, or first-ever sync hasn't
+      // completed. Try a sync: if native grants return true, we'll connect.
+      // If not, we show "not-connected".
+      setStatus('syncing');
+      const result = await runForegroundSync();
+      if (result.ok) {
+        applySyncResult(result);
+      } else if (result.reason === 'not_requested' || result.reason === 'revoked') {
+        setStatus('not-connected');
+      } else {
+        applySyncResult(result);
+      }
+    } catch {
+      setStatus('not-connected');
+    }
+  }, [applySyncResult]);
+
+  useEffect(() => {
+    probeStatus();
+
+    const handle = App.addListener('appStateChange', ({ isActive }) => {
+      if (isActive) probeStatus();
+    });
+    return () => {
+      handle.then(h => h.remove());
+    };
+  }, [probeStatus]);
+
+  const handleConnect = useCallback(async () => {
+    setStatus('syncing');
+    setErrorMessage(null);
+    try {
+      const result = await connectHealthKit();
+      if (result.ok || result.reason === 'not_requested') {
+        // connectHealthKit always calls markPermissionsRequested — if the user
+        // had already granted before, we just re-sync here.
+        applySyncResult(result);
+      } else if (result.reason === 'revoked') {
+        setStatus('not-connected');
+        setErrorMessage('Permission denied. Grant access in Apple Health to connect.');
+      } else {
+        applySyncResult(result);
+      }
+    } catch (e) {
+      setStatus('error');
+      setErrorMessage(e instanceof Error ? e.message : 'Could not connect — try again.');
+    }
+  }, [applySyncResult]);
+
+  const handleSyncNow = useCallback(async () => {
+    setStatus('syncing');
+    markPermissionsRequested();
+    try {
+      const result = await runForegroundSync();
+      applySyncResult(result);
+    } catch {
+      setStatus('error');
+      setErrorMessage('Sync failed — try again.');
+    }
+  }, [applySyncResult]);
+
+  const handleManageInHealth = useCallback(() => {
+    // Prefer the Health app deep link; fall back to iOS Settings if unavailable.
+    try {
+      window.open('x-apple-health://', '_system');
+    } catch {
+      window.open('app-settings:', '_system');
+    }
+  }, []);
+
+  if (status === 'unavailable') {
+    return (
+      <div>
+        <p className="text-label-section mb-1 px-1">Apple Health</p>
+        <div className="ios-section">
+          <div className="px-4 py-3">
+            <p className="text-sm font-medium">Unavailable on this device</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              HealthKit needs an iPhone. Connect from the Rebirth iOS app to sync your workouts and recovery data.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const showSyncError = status === 'error' && consecutiveErrors >= 3;
+
+  return (
+    <div>
+      <p className="text-label-section mb-1 px-1">Apple Health</p>
+      <div className="ios-section">
+        {/* Status row */}
+        <div className="ios-row justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 rounded-[10px] flex items-center justify-center flex-shrink-0 bg-pink-500/20">
+              <HeartPulse className="w-4 h-4 text-pink-400" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium">
+                {status === 'connected' && 'Connected'}
+                {status === 'not-connected' && 'Not connected'}
+                {status === 'syncing' && 'Syncing…'}
+                {status === 'error' && (showSyncError ? 'Sync error' : 'Connected')}
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {status === 'connected' && lastSyncAt && `Last synced ${formatAgo(lastSyncAt)}`}
+                {status === 'not-connected' && 'Tap Connect to share workouts, heart rate, and sleep with your coach.'}
+                {status === 'syncing' && 'Fetching from HealthKit…'}
+                {showSyncError && (errorMessage ?? 'Tap Sync now to retry.')}
+                {status === 'error' && !showSyncError && lastSyncAt && `Last synced ${formatAgo(lastSyncAt)}`}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Action rows */}
+        {status === 'not-connected' && (
+          <button
+            onClick={handleConnect}
+            className="ios-row justify-between w-full text-left"
+          >
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 rounded-[10px] flex items-center justify-center flex-shrink-0 bg-primary">
+                <RefreshCw className="w-4 h-4 text-primary-foreground" />
+              </div>
+              <span className="text-sm font-medium text-primary">Connect to Apple Health</span>
+            </div>
+          </button>
+        )}
+
+        {(status === 'connected' || status === 'syncing' || status === 'error') && (
+          <>
+            <button
+              onClick={handleSyncNow}
+              disabled={status === 'syncing'}
+              className="ios-row justify-between w-full text-left disabled:opacity-50"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 rounded-[10px] flex items-center justify-center flex-shrink-0 bg-blue-500/20">
+                  <RefreshCw
+                    className={`w-4 h-4 text-blue-400 ${status === 'syncing' ? 'animate-spin' : ''}`}
+                  />
+                </div>
+                <span className="text-sm font-medium">Sync now</span>
+              </div>
+            </button>
+            <button
+              onClick={handleManageInHealth}
+              className="ios-row justify-between w-full text-left"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 rounded-[10px] flex items-center justify-center flex-shrink-0 bg-secondary">
+                  <ExternalLink className="w-4 h-4 text-muted-foreground" />
+                </div>
+                <span className="text-sm font-medium">Manage in Apple Health</span>
+              </div>
+              <ExternalLink className="h-4 w-4 text-muted-foreground" />
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Reads / writes summary */}
+      <div className="px-1 mt-2 space-y-1">
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Reads:</span>{' '}
+          workouts, steps, active/basal energy, heart rate, HRV, resting HR, VO2 max, sleep, exercise minutes.
+        </p>
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Writes:</span>{' '}
+          your Rebirth workouts, meals (energy, protein, carbs, fat, water), and body composition from InBody scans.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HealthSection.tsx
+++ b/src/components/HealthSection.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
 import { App } from '@capacitor/app';
-import { Activity, Flame, Footprints, ExternalLink } from 'lucide-react';
+import { Activity, Flame, Footprints, ChevronRight } from 'lucide-react';
 import { fetchHealthSummary, type HealthSummary } from '@/lib/healthkit';
 
 type State =
@@ -68,23 +69,15 @@ export function HealthSection() {
       <div>
         <p className="text-xs font-semibold text-primary uppercase tracking-wide mb-1 px-1">Today&apos;s Health</p>
         <div className="ios-section">
-          <div className="flex items-center justify-between px-4 py-4 gap-3">
+          <Link href="/settings" className="ios-row justify-between">
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium">HealthKit access needed</p>
-              <p className="text-xs text-muted-foreground mt-0.5">Enable Health access in iOS Settings to see steps, calories, and workouts here.</p>
+              <p className="text-sm font-medium">Connect Apple Health</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Share workouts, heart rate, and sleep with your coach.
+              </p>
             </div>
-            <button
-              onClick={() => {
-                // Deep-link to app settings — Capacitor doesn't expose this directly,
-                // but the URL scheme works on iOS 8+
-                window.open('app-settings:', '_system');
-              }}
-              className="flex items-center gap-1 text-xs text-primary font-medium whitespace-nowrap flex-shrink-0 min-h-[36px] px-1"
-            >
-              Open Settings
-              <ExternalLink className="h-3 w-3" />
-            </button>
-          </div>
+            <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+          </Link>
         </div>
       </div>
     );

--- a/src/db/local.ts
+++ b/src/db/local.ts
@@ -1,5 +1,4 @@
 import Dexie, { type Table } from 'dexie';
-import { apiBase } from '@/lib/api/client';
 
 // ─── Local table types ─────────────────────────────────────────────────────────
 
@@ -148,9 +147,15 @@ export async function setMeta(key: string, value: string | number): Promise<void
   await db._meta.put({ key, value });
 }
 
-// ─── Exercise hydration ────────────────────────────────────────────────────────
-
-const HYDRATE_STALE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+// ─── Exercise bootstrap (first-install only) ───────────────────────────────────
+//
+// The exercise catalog is owned by sync pull (see src/lib/sync.ts and
+// src/app/api/sync/pull/route.ts). This function only seeds the bundled
+// JSON catalog on a completely empty Dexie so a brand-new install can render
+// something before the first network sync completes. After that, sync is
+// authoritative — catalog updates (new custom exercises, admin additions,
+// cross-device creations) arrive in the same envelope as the workout_exercises
+// that reference them, so the two can never drift.
 
 type HydrationListener = (ready: boolean) => void;
 const hydrationListeners = new Set<HydrationListener>();
@@ -170,56 +175,23 @@ function setExercisesReady(ready: boolean) {
 export async function hydrateExercises(): Promise<void> {
   try {
     const count = await db.exercises.count();
-    console.log('[hydrate] exercises in IndexedDB:', count);
-
-    // If empty, seed from bundled catalog immediately (no network needed)
-    if (count === 0) {
-      try {
-        const bundledRes = await fetch('/exercises-catalog.json');
-        console.log('[hydrate] bundled catalog fetch:', bundledRes.status);
-        if (bundledRes.ok) {
-          const bundled: LocalExercise[] = await bundledRes.json();
-          console.log('[hydrate] seeding', bundled.length, 'exercises from bundled catalog');
-          // Use Dexie transaction to batch all puts in one IDB transaction
-          await db.transaction('rw', db.exercises, async () => {
-            for (const ex of bundled) {
-              await db.exercises.put(ex);
-            }
-          });
-          await setMeta('exercises_hydrated_at', Date.now());
-          console.log('[hydrate] bundled seed complete');
-        }
-      } catch (e) {
-        console.warn('[hydrate] bundled catalog failed:', e);
-      }
-    }
-
-    const freshCount = await db.exercises.count();
-    if (freshCount > 0) {
+    if (count > 0) {
       setExercisesReady(true);
-      console.log('[hydrate] exercises ready:', freshCount);
-    }
-
-    const lastHydrated = await getMeta('exercises_hydrated_at');
-    if (lastHydrated && Date.now() - Number(lastHydrated) < HYDRATE_STALE_MS) {
-      return; // Fresh enough
-    }
-
-    // Try API for latest data (may include new custom exercises)
-    const res = await fetch(`${apiBase()}/api/exercises?limit=10000`);
-    if (!res.ok) {
-      console.warn('[hydrate] API fetch failed:', res.status);
       return;
     }
 
-    const exercises: LocalExercise[] = await res.json();
-    console.log('[hydrate] API returned', exercises.length, 'exercises');
+    // Empty Dexie — seed from bundled catalog so the UI has something to render
+    // while the first sync pull completes. Sync will overwrite these with fresh
+    // server data on its first successful run.
+    const bundledRes = await fetch('/exercises-catalog.json');
+    if (!bundledRes.ok) {
+      console.warn('[hydrate] bundled catalog fetch failed:', bundledRes.status);
+      return;
+    }
+    const bundled: LocalExercise[] = await bundledRes.json();
     await db.transaction('rw', db.exercises, async () => {
-      for (const ex of exercises) {
-        await db.exercises.put(ex);
-      }
+      for (const ex of bundled) await db.exercises.put(ex);
     });
-    await setMeta('exercises_hydrated_at', Date.now());
     setExercisesReady(true);
   } catch (e) {
     console.warn('[hydrate] error:', e);

--- a/src/db/migrations/017_healthkit.sql
+++ b/src/db/migrations/017_healthkit.sql
@@ -1,0 +1,103 @@
+-- Migration 017: HealthKit integration.
+-- 4 tables: daily aggregates, workouts (full records for reconciliation),
+-- per-metric sync state (anchor or window_end), and writeback tracking.
+--
+-- Design notes:
+-- * Daily aggregates, NOT raw samples. Raw HR at 1Hz would be millions of rows;
+--   coaching uses daily summaries. Workouts get full records since they're sparse.
+-- * Quantity metrics (steps, HR, HRV...) use last_window_end — HKStatisticsCollectionQuery
+--   has no anchor support, so we re-query a rolling 2-day window.
+-- * Sleep and workouts use last_anchor — HKAnchoredObjectQuery gives real
+--   incremental delivery including deletions.
+-- * healthkit_writeback tracks HK sample UUIDs we authored so meal/scan edits
+--   can delete the old samples before writing new ones.
+
+-- ── Daily aggregates (one row per user/metric/date) ──────────────────────────
+
+CREATE TABLE IF NOT EXISTS healthkit_daily (
+  metric TEXT NOT NULL,
+  -- metric enum: steps, active_energy, basal_energy, heart_rate, hrv,
+  -- resting_hr, vo2_max, exercise_minutes,
+  -- sleep_asleep, sleep_inbed, sleep_rem, sleep_deep, sleep_core, sleep_awake
+  date DATE NOT NULL,
+  value_min NUMERIC,           -- metric-appropriate (HR min bpm / unused for steps)
+  value_max NUMERIC,           -- metric-appropriate
+  value_avg NUMERIC,           -- primary summary for discreteAverage metrics
+  value_sum NUMERIC,           -- primary summary for cumulative metrics
+  count INTEGER,               -- # underlying samples (confidence signal)
+  source_primary TEXT,         -- most-common source bundle id in the window
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (metric, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_healthkit_daily_date ON healthkit_daily(date DESC);
+CREATE INDEX IF NOT EXISTS idx_healthkit_daily_metric_date ON healthkit_daily(metric, date DESC);
+
+-- ── HealthKit workouts (full records for reconciliation) ─────────────────────
+
+CREATE TABLE IF NOT EXISTS healthkit_workouts (
+  hk_uuid TEXT PRIMARY KEY,
+  activity_type TEXT NOT NULL,          -- 'traditional_strength', 'running', 'cycling', ...
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ NOT NULL,
+  duration_s INTEGER NOT NULL,
+  total_energy_kcal NUMERIC,
+  total_distance_m NUMERIC,
+  avg_heart_rate INTEGER,
+  max_heart_rate INTEGER,
+  source_name TEXT,
+  source_bundle_id TEXT,
+  metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  workout_uuid TEXT,                    -- FK to workouts.uuid if matched
+  source TEXT NOT NULL DEFAULT 'hk_only'
+    CHECK (source IN ('user_logged', 'hk_only', 'matched')),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  FOREIGN KEY (workout_uuid) REFERENCES workouts(uuid) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_healthkit_workouts_start ON healthkit_workouts(start_at DESC);
+CREATE INDEX IF NOT EXISTS idx_healthkit_workouts_source_start
+  ON healthkit_workouts(source, start_at DESC);
+CREATE INDEX IF NOT EXISTS idx_healthkit_workouts_workout_uuid
+  ON healthkit_workouts(workout_uuid);
+
+DROP TRIGGER IF EXISTS healthkit_workouts_updated_at ON healthkit_workouts;
+CREATE TRIGGER healthkit_workouts_updated_at
+  BEFORE UPDATE ON healthkit_workouts
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ── Incremental sync state per metric ────────────────────────────────────────
+-- Quantity metrics use last_window_end (rolling re-query, no anchor API).
+-- Sleep and workouts use last_anchor (HKAnchoredObjectQuery).
+
+CREATE TABLE IF NOT EXISTS healthkit_sync_state (
+  metric TEXT PRIMARY KEY,
+  last_anchor BYTEA,                    -- HKQueryAnchor serialized (sleep, workouts only)
+  last_window_end TIMESTAMPTZ,          -- for quantity aggregates
+  last_sync_at TIMESTAMPTZ,
+  last_successful_sync_at TIMESTAMPTZ,
+  last_error TEXT,                      -- 'permission_revoked' | 'timeout' | 'invalid_anchor' | ...
+  last_error_at TIMESTAMPTZ
+);
+
+-- ── Writeback tracking (Rebirth-authored HK samples) ─────────────────────────
+-- Remembers the HK sample UUIDs we created so meal/scan edits can delete the
+-- old samples cleanly. source_kind + source_uuid + hk_type is unique so each
+-- (meal, 'dietary_energy') has exactly one tracked HK UUID at a time.
+
+CREATE TABLE IF NOT EXISTS healthkit_writeback (
+  source_kind TEXT NOT NULL
+    CHECK (source_kind IN ('meal', 'inbody', 'workout')),
+  source_uuid TEXT NOT NULL,
+  hk_type TEXT NOT NULL,
+  hk_uuid TEXT NOT NULL,
+  pending_delete BOOLEAN NOT NULL DEFAULT FALSE,
+  written_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (source_kind, source_uuid, hk_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_healthkit_writeback_hk_uuid
+  ON healthkit_writeback(hk_uuid);
+CREATE INDEX IF NOT EXISTS idx_healthkit_writeback_pending
+  ON healthkit_writeback(pending_delete) WHERE pending_delete = TRUE;

--- a/src/db/migrations/018_exercises_updated_at.sql
+++ b/src/db/migrations/018_exercises_updated_at.sql
@@ -1,0 +1,18 @@
+-- Migration 018: exercises.updated_at + trigger
+--
+-- Why: the sync pull endpoint now emits exercises alongside workout_exercises so the
+-- client's Dexie catalog can never drift from the UUIDs that workout rows reference.
+-- Incremental pull needs an indexed updated_at to filter by `since`.
+--
+-- See: src/app/api/sync/pull/route.ts (server-side consumer)
+--      src/lib/sync.ts (client-side consumer)
+
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+UPDATE exercises SET updated_at = COALESCE(created_at, NOW()) WHERE updated_at IS NULL;
+
+DROP TRIGGER IF EXISTS exercises_updated_at ON exercises;
+CREATE TRIGGER exercises_updated_at
+  BEFORE UPDATE ON exercises
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE INDEX IF NOT EXISTS idx_exercises_updated_at ON exercises(updated_at);

--- a/src/features/health/healthSync.ts
+++ b/src/features/health/healthSync.ts
@@ -1,0 +1,344 @@
+/**
+ * HealthKit → server sync orchestrator. Runs in the Capacitor app (device has
+ * HealthKit; server doesn't). Called on app resume, Settings mount, or an
+ * explicit "Sync now" tap.
+ *
+ * Flow:
+ *   1. GET /api/healthkit/sync  → per-metric state (window_end / anchor)
+ *   2. For each quantity metric: fetchDailyAggregates with 2-day overlap
+ *   3. fetchSleepNights with anchor
+ *   4. fetchWorkouts with anchor
+ *   5. POST /api/healthkit/sync with all results + new state
+ *   6. mirrorPendingWrites(): mirror new/edited meals + InBody scans → HK
+ *
+ * Failures per-metric are isolated — one broken metric doesn't stop the rest.
+ */
+
+import {
+  HealthKit,
+  QUANTITY_METRICS,
+  type DailyAggregateRow,
+  type SleepNight,
+  type FullHKWorkout,
+  type WrittenSample,
+} from '@/lib/healthkit';
+import { apiBase } from '@/lib/api/client';
+import { markPermissionsRequested } from './healthService';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface MetricSyncState {
+  last_anchor: string | null;         // base64
+  last_window_end: string | null;     // ISO
+  last_sync_at: string | null;
+  last_successful_sync_at: string | null;
+  last_error: string | null;
+  last_error_at: string | null;
+}
+
+export type SyncStateByMetric = Record<string, MetricSyncState>;
+
+export interface SyncResult {
+  ok: boolean;
+  reason?: 'unavailable' | 'not_requested' | 'revoked' | 'network' | 'unknown';
+  metrics_synced: number;
+  workouts_synced: number;
+  nights_synced: number;
+  samples_mirrored: number;
+  duration_ms: number;
+}
+
+interface PendingNutrition {
+  uuid: string;
+  logged_at: string;
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  hydration_ml: number | null;
+}
+
+interface PendingInbody {
+  uuid: string;
+  scanned_at: string;
+  weight_kg: number | null;
+  pbf_pct: number | null;
+  smm_kg: number | null;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const BACKFILL_DAYS = 90;
+const OVERLAP_DAYS = 2;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/** Idempotent foreground sync. Safe to call on every app resume. */
+export async function runForegroundSync(): Promise<SyncResult> {
+  const started = performance.now();
+  const metricsSyncedSet = new Set<string>();
+  let workoutsSynced = 0;
+  let nightsSynced = 0;
+
+  try {
+    const { available } = await HealthKit.isAvailable();
+    if (!available) {
+      return emptyResult('unavailable', started);
+    }
+  } catch {
+    return emptyResult('unknown', started);
+  }
+  // Note: we don't gate on localStorage here. HealthKit reads are silent on
+  // denied permissions (return empty), not sheet-triggering. If a metric comes
+  // back with zero data, the server-state-based UI handles that gracefully.
+
+  let state: SyncStateByMetric = {};
+  try {
+    const res = await fetch(`${apiBase()}/api/healthkit/sync`);
+    if (res.ok) state = ((await res.json()) as { state: SyncStateByMetric }).state ?? {};
+  } catch {
+    // Treat as empty state — first sync.
+  }
+
+  const now = Date.now();
+  const backfillStart = now - BACKFILL_DAYS * DAY_MS;
+
+  // ── Quantity metrics ──────────────────────────────────────────────────────
+  const dailyRows: DailyAggregateRow[] = [];
+  const quantityStateUpdates: Array<{ metric: string; last_window_end: string; last_error: string | null }> = [];
+
+  for (const metric of QUANTITY_METRICS) {
+    try {
+      const prev = state[metric];
+      const startMs = prev?.last_window_end
+        ? new Date(prev.last_window_end).getTime() - OVERLAP_DAYS * DAY_MS
+        : backfillStart;
+      const { results } = await HealthKit.fetchDailyAggregates({
+        metrics: [metric],
+        startTime: startMs,
+        endTime: now,
+      });
+      dailyRows.push(...results);
+      metricsSyncedSet.add(metric);
+      quantityStateUpdates.push({
+        metric,
+        last_window_end: new Date(now).toISOString(),
+        last_error: null,
+      });
+    } catch (e) {
+      quantityStateUpdates.push({
+        metric,
+        last_window_end: state[metric]?.last_window_end ?? new Date(backfillStart).toISOString(),
+        last_error: errorMessage(e),
+      });
+    }
+  }
+
+  // ── Sleep (anchored) ──────────────────────────────────────────────────────
+  let sleep: SleepNight[] = [];
+  let sleepAnchor: string | null = null;
+  let sleepError: string | null = null;
+  try {
+    const prev = state['sleep'];
+    const startMs = prev?.last_anchor ? backfillStart : backfillStart;
+    const { nights, nextAnchor } = await HealthKit.fetchSleepNights({
+      startTime: startMs,
+      endTime: now,
+      anchor: prev?.last_anchor ?? undefined,
+    });
+    sleep = nights;
+    sleepAnchor = nextAnchor;
+    nightsSynced = nights.length;
+    metricsSyncedSet.add('sleep');
+  } catch (e) {
+    sleepError = errorMessage(e);
+  }
+
+  // ── Workouts (anchored) ───────────────────────────────────────────────────
+  let workouts: FullHKWorkout[] = [];
+  let deletedWorkoutUuids: string[] = [];
+  let workoutAnchor: string | null = null;
+  let workoutError: string | null = null;
+  try {
+    const prev = state['workouts'];
+    const startMs = prev?.last_anchor ? backfillStart : backfillStart;
+    const { workouts: fetched, deleted, nextAnchor } = await HealthKit.fetchWorkouts({
+      startTime: startMs,
+      endTime: now,
+      anchor: prev?.last_anchor ?? undefined,
+    });
+    workouts = fetched;
+    deletedWorkoutUuids = deleted;
+    workoutAnchor = nextAnchor;
+    workoutsSynced = fetched.length;
+    metricsSyncedSet.add('workouts');
+  } catch (e) {
+    workoutError = errorMessage(e);
+  }
+
+  // ── POST everything in one sync call ──────────────────────────────────────
+  const stateUpdates = [
+    ...quantityStateUpdates,
+    { metric: 'sleep', last_anchor: sleepAnchor, last_error: sleepError },
+    { metric: 'workouts', last_anchor: workoutAnchor, last_error: workoutError },
+  ];
+
+  try {
+    await fetch(`${apiBase()}/api/healthkit/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        daily: dailyRows,
+        sleep,
+        workouts,
+        deleted_workouts: deletedWorkoutUuids,
+        state_updates: stateUpdates,
+      }),
+    });
+  } catch {
+    return { ...emptyResult('network', started), metrics_synced: metricsSyncedSet.size };
+  }
+
+  // ── Mirror pending nutrition + InBody writes to HK ────────────────────────
+  let samplesMirrored = 0;
+  try {
+    samplesMirrored = await mirrorPendingWrites();
+  } catch {
+    // Mirror failures shouldn't fail the whole sync.
+  }
+
+  return {
+    ok: true,
+    metrics_synced: metricsSyncedSet.size,
+    workouts_synced: workoutsSynced,
+    nights_synced: nightsSynced,
+    samples_mirrored: samplesMirrored,
+    duration_ms: Math.round(performance.now() - started),
+  };
+}
+
+/**
+ * Request HealthKit permissions, mark that we've asked, and kick off first sync.
+ * Called from the Connect button in Settings.
+ */
+export async function connectHealthKit(): Promise<SyncResult> {
+  const { granted } = await HealthKit.requestPermissions();
+  markPermissionsRequested();
+  if (!granted) {
+    return emptyResult('revoked', performance.now());
+  }
+  return runForegroundSync();
+}
+
+// ── Mirror pending nutrition + InBody writes to HK ───────────────────────────
+
+export async function mirrorPendingWrites(): Promise<number> {
+  let pending: { nutrition: PendingNutrition[]; inbody: PendingInbody[] };
+  try {
+    const res = await fetch(`${apiBase()}/api/healthkit/pending-mirror`);
+    if (!res.ok) return 0;
+    pending = await res.json();
+  } catch {
+    return 0;
+  }
+
+  let samplesWritten = 0;
+
+  // Nutrition
+  for (const meal of pending.nutrition) {
+    try {
+      // Read existing writeback rows and delete stale HK samples first.
+      const existingRes = await fetch(
+        `${apiBase()}/api/healthkit/writeback?source_kind=meal&source_uuid=${encodeURIComponent(meal.uuid)}`
+      );
+      if (existingRes.ok) {
+        const { samples: prior } = (await existingRes.json()) as {
+          samples: Array<{ hk_type: string; hk_uuid: string; pending_delete: boolean }>;
+        };
+        if (prior.length > 0) {
+          await HealthKit.deleteSamples({ uuids: prior.map(s => s.hk_uuid) }).catch(() => undefined);
+        }
+      }
+
+      const { samples } = await HealthKit.saveNutrition({
+        timestamp: new Date(meal.logged_at).getTime(),
+        mealUuid: meal.uuid,
+        kcal: meal.calories ?? undefined,
+        proteinG: meal.protein_g ?? undefined,
+        carbsG: meal.carbs_g ?? undefined,
+        fatG: meal.fat_g ?? undefined,
+        waterMl: meal.hydration_ml ?? undefined,
+      });
+      samplesWritten += samples.length;
+      await postWriteback('meal', meal.uuid, samples);
+    } catch {
+      // Skip this meal; retry next sync.
+    }
+  }
+
+  // InBody
+  for (const scan of pending.inbody) {
+    try {
+      const existingRes = await fetch(
+        `${apiBase()}/api/healthkit/writeback?source_kind=inbody&source_uuid=${encodeURIComponent(scan.uuid)}`
+      );
+      if (existingRes.ok) {
+        const { samples: prior } = (await existingRes.json()) as {
+          samples: Array<{ hk_type: string; hk_uuid: string }>;
+        };
+        if (prior.length > 0) {
+          await HealthKit.deleteSamples({ uuids: prior.map(s => s.hk_uuid) }).catch(() => undefined);
+        }
+      }
+
+      const { samples } = await HealthKit.saveBodyComposition({
+        timestamp: new Date(scan.scanned_at).getTime(),
+        inbodyUuid: scan.uuid,
+        weightKg: scan.weight_kg ?? undefined,
+        bodyFatPct: scan.pbf_pct ?? undefined,
+        // Use SMM (skeletal muscle mass) as the lean-mass proxy — most apps that
+        // consume "leanBodyMass" treat it as SMM-ish for fitness purposes.
+        leanKg: scan.smm_kg ?? undefined,
+      });
+      samplesWritten += samples.length;
+      await postWriteback('inbody', scan.uuid, samples);
+    } catch {
+      // Skip this scan; retry next sync.
+    }
+  }
+
+  return samplesWritten;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function postWriteback(
+  kind: 'meal' | 'inbody' | 'workout',
+  uuid: string,
+  samples: WrittenSample[],
+): Promise<void> {
+  if (samples.length === 0) return;
+  await fetch(`${apiBase()}/api/healthkit/writeback`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source_kind: kind, source_uuid: uuid, samples }),
+  }).catch(() => undefined);
+}
+
+function emptyResult(reason: SyncResult['reason'], started: number): SyncResult {
+  return {
+    ok: false,
+    reason,
+    metrics_synced: 0,
+    workouts_synced: 0,
+    nights_synced: 0,
+    samples_mirrored: 0,
+    duration_ms: Math.round(performance.now() - started),
+  };
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}

--- a/src/lib/healthkit.ts
+++ b/src/lib/healthkit.ts
@@ -38,16 +38,117 @@ export interface HealthSummary {
   recentWorkouts: HealthWorkout[];
 }
 
+// ── Quantity metrics supported by fetchDailyAggregates ───────────────────────
+
+export type QuantityMetric =
+  | 'steps'
+  | 'active_energy'
+  | 'basal_energy'
+  | 'exercise_minutes'
+  | 'heart_rate'
+  | 'hrv'
+  | 'resting_hr'
+  | 'vo2_max';
+
+export const QUANTITY_METRICS: QuantityMetric[] = [
+  'steps', 'active_energy', 'basal_energy', 'exercise_minutes',
+  'heart_rate', 'hrv', 'resting_hr', 'vo2_max',
+];
+
+export interface DailyAggregateRow {
+  metric: QuantityMetric;
+  date: string;            // YYYY-MM-DD
+  value_min?: number;
+  value_max?: number;
+  value_avg?: number;
+  value_sum?: number;
+  count?: number;
+  source_primary?: string;
+}
+
+export interface SleepNight {
+  date: string;            // YYYY-MM-DD (wake date)
+  start_at: number;        // epoch ms
+  end_at: number;          // epoch ms
+  asleep_min: number;
+  rem_min: number;
+  deep_min: number;
+  core_min: number;
+  awake_min: number;
+  in_bed_min: number;
+}
+
+export interface FullHKWorkout {
+  hk_uuid: string;
+  activity_type: string;
+  start_at: number;        // epoch ms
+  end_at: number;          // epoch ms
+  duration_s: number;
+  total_energy_kcal?: number | null;
+  total_distance_m?: number | null;
+  source_name?: string;
+  source_bundle_id?: string;
+  metadata_json?: string;
+  rebirth_workout_uuid?: string;   // if we authored it
+}
+
+export interface WrittenSample {
+  hk_uuid: string;
+  hk_type: string;
+}
+
 interface HealthKitPlugin {
   isAvailable(): Promise<{ available: boolean }>;
   requestPermissions(): Promise<{ granted: boolean }>;
   checkPermissionStatus(): Promise<{ statuses: Record<string, string> }>;
-  saveWorkout(options: SaveWorkoutOptions): Promise<{ saved: boolean }>;
+
+  // Legacy reads (kept for HealthSection compat)
+  saveWorkout(options: SaveWorkoutOptions): Promise<{ saved: boolean; hk_uuid?: string }>;
   getSteps(options: { startTime: number; endTime: number }): Promise<{ value: number }>;
   getActiveCalories(options: { startTime: number; endTime: number }): Promise<{ value: number }>;
   getRecentWorkouts(options: { startTime: number }): Promise<{ workouts: HealthWorkout[] }>;
   getWorkouts(options: { startTime: number; endTime: number }): Promise<{ workouts: WorkoutRecord[] }>;
   getHeartRate(options: { startTime: number; endTime: number }): Promise<{ samples: HeartRateSample[] }>;
+
+  // New anchored / aggregated reads
+  fetchDailyAggregates(options: {
+    metrics: QuantityMetric[];
+    startTime: number;   // epoch ms
+    endTime: number;     // epoch ms
+  }): Promise<{ results: DailyAggregateRow[] }>;
+
+  fetchSleepNights(options: {
+    startTime: number;
+    endTime: number;
+    anchor?: string;     // base64-encoded HKQueryAnchor
+  }): Promise<{ nights: SleepNight[]; deleted: string[]; nextAnchor: string }>;
+
+  fetchWorkouts(options: {
+    startTime: number;
+    endTime: number;
+    anchor?: string;
+  }): Promise<{ workouts: FullHKWorkout[]; deleted: string[]; nextAnchor: string }>;
+
+  // Writes
+  saveNutrition(options: {
+    timestamp: number;   // epoch ms
+    mealUuid: string;
+    kcal?: number;
+    proteinG?: number;
+    carbsG?: number;
+    fatG?: number;
+    waterMl?: number;
+  }): Promise<{ saved: boolean; samples: WrittenSample[] }>;
+
+  saveBodyComposition(options: {
+    timestamp: number;
+    inbodyUuid: string;
+    weightKg?: number;
+    bodyFatPct?: number;
+    leanKg?: number;
+  }): Promise<{ saved: boolean; samples: WrittenSample[] }>;
+
+  deleteSamples(options: { uuids: string[] }): Promise<{ deleted: number; failed: string[] }>;
 }
 
 export const HealthKit = registerPlugin<HealthKitPlugin>('HealthKit');

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -1497,6 +1497,329 @@ async function getBodyNormRangesTool(args: Record<string, unknown>) {
   return toolResult(ranges);
 }
 
+// ── HealthKit tools ───────────────────────────────────────────────────────────
+
+type HealthKitStatus = 'connected' | 'not_requested' | 'revoked' | 'unavailable';
+
+type SnapshotField =
+  | 'sleep_last_night' | 'hrv' | 'resting_hr' | 'vo2_max'
+  | 'activity_today' | 'unlogged_workouts_24h' | 'data_quality';
+
+const VALID_SERIES_METRICS = [
+  'steps', 'active_energy', 'basal_energy', 'exercise_minutes',
+  'heart_rate', 'hrv', 'resting_hr', 'vo2_max',
+  'sleep_asleep', 'sleep_rem', 'sleep_deep', 'sleep_core', 'sleep_awake', 'sleep_inbed',
+] as const;
+
+const VALID_WORKOUT_SOURCES = ['user_logged', 'matched', 'hk_only', 'all'] as const;
+
+async function getHealthKitStatus(): Promise<{ status: HealthKitStatus; last_sync_at: string | null; last_successful_sync_at: string | null }> {
+  const states = await query<{
+    last_sync_at: string | null;
+    last_successful_sync_at: string | null;
+    last_error: string | null;
+  }>(`SELECT last_sync_at, last_successful_sync_at, last_error
+      FROM healthkit_sync_state`);
+
+  if (states.length === 0) {
+    return { status: 'not_requested', last_sync_at: null, last_successful_sync_at: null };
+  }
+
+  const anySuccess = states.some(s => s.last_successful_sync_at != null);
+  const allRevoked = states.length > 0 && states.every(s => s.last_error === 'permission_revoked');
+
+  const lastSync = states.reduce<string | null>((acc, s) => {
+    if (!s.last_sync_at) return acc;
+    return !acc || s.last_sync_at > acc ? s.last_sync_at : acc;
+  }, null);
+
+  const lastSuccess = states.reduce<string | null>((acc, s) => {
+    if (!s.last_successful_sync_at) return acc;
+    return !acc || s.last_successful_sync_at > acc ? s.last_successful_sync_at : acc;
+  }, null);
+
+  if (allRevoked) return { status: 'revoked', last_sync_at: lastSync, last_successful_sync_at: lastSuccess };
+  if (!anySuccess) return { status: 'not_requested', last_sync_at: lastSync, last_successful_sync_at: null };
+  return { status: 'connected', last_sync_at: lastSync, last_successful_sync_at: lastSuccess };
+}
+
+function notConnectedResponse(status: HealthKitStatus) {
+  const reason = status === 'unavailable' ? 'unavailable'
+    : status === 'revoked' ? 'revoked'
+    : 'not_requested';
+  return {
+    status: 'not_connected' as const,
+    reason,
+    message: 'Ask the user to open Rebirth → Settings → Apple Health to connect their HealthKit data.',
+  };
+}
+
+async function getHealthSnapshot(args: Record<string, unknown>) {
+  const status = await getHealthKitStatus();
+  if (status.status !== 'connected') return toolResult(notConnectedResponse(status.status));
+
+  const asOf = typeof args.as_of === 'string' ? args.as_of.slice(0, 10) : new Date().toISOString().slice(0, 10);
+  const windowDays = typeof args.window_days === 'number' ? Math.min(Math.max(args.window_days, 1), 90) : 7;
+  const fields = Array.isArray(args.fields) ? (args.fields as string[]) : null;
+
+  const includes = (f: SnapshotField) => fields == null || fields.includes(f);
+
+  // Dates
+  const asOfDate = new Date(asOf);
+  const yesterday = new Date(asOfDate);
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+  const yesterdayIso = yesterday.toISOString().slice(0, 10);
+
+  const windowStart = new Date(asOfDate);
+  windowStart.setUTCDate(windowStart.getUTCDate() - windowDays);
+  const windowStartIso = windowStart.toISOString().slice(0, 10);
+
+  const baselineStart = new Date(asOfDate);
+  baselineStart.setUTCDate(baselineStart.getUTCDate() - 30);
+  const baselineStartIso = baselineStart.toISOString().slice(0, 10);
+
+  const out: Record<string, unknown> = { as_of: asOf };
+
+  if (includes('sleep_last_night')) {
+    const rows = await query<{ metric: string; value_sum: number | null }>(
+      `SELECT metric, value_sum FROM healthkit_daily
+       WHERE date = $1 AND metric LIKE 'sleep_%'`,
+      [yesterdayIso]
+    );
+    if (rows.length > 0) {
+      const byMetric = Object.fromEntries(rows.map(r => [r.metric, r.value_sum]));
+      out.sleep_last_night = {
+        date: yesterdayIso,
+        total_asleep_min: byMetric['sleep_asleep'] ?? null,
+        rem_min: byMetric['sleep_rem'] ?? null,
+        deep_min: byMetric['sleep_deep'] ?? null,
+        core_min: byMetric['sleep_core'] ?? null,
+        awake_min: byMetric['sleep_awake'] ?? null,
+        in_bed_min: byMetric['sleep_inbed'] ?? null,
+      };
+    }
+  }
+
+  if (includes('hrv')) {
+    const last = await queryOne<{ value_avg: number | null }>(
+      `SELECT value_avg FROM healthkit_daily
+       WHERE metric = 'hrv' AND date <= $1 ORDER BY date DESC LIMIT 1`,
+      [asOf]
+    );
+    const window = await queryOne<{ avg: number | null }>(
+      `SELECT AVG(value_avg) AS avg FROM healthkit_daily
+       WHERE metric = 'hrv' AND date > $1 AND date <= $2`,
+      [windowStartIso, asOf]
+    );
+    const baseline = await queryOne<{ avg: number | null }>(
+      `SELECT AVG(value_avg) AS avg FROM healthkit_daily
+       WHERE metric = 'hrv' AND date > $1 AND date <= $2`,
+      [baselineStartIso, asOf]
+    );
+    if (last || window?.avg || baseline?.avg) {
+      const deltaPct = (last?.value_avg != null && baseline?.avg != null && baseline.avg > 0)
+        ? Math.round(((last.value_avg - baseline.avg) / baseline.avg) * 1000) / 10
+        : null;
+      out.hrv = {
+        last: last?.value_avg ?? null,
+        window_avg: window?.avg ?? null,
+        baseline_30d_avg: baseline?.avg ?? null,
+        delta_pct: deltaPct,
+      };
+    }
+  }
+
+  if (includes('resting_hr')) {
+    const last = await queryOne<{ value_avg: number | null }>(
+      `SELECT value_avg FROM healthkit_daily
+       WHERE metric = 'resting_hr' AND date <= $1 ORDER BY date DESC LIMIT 1`,
+      [asOf]
+    );
+    const window = await queryOne<{ avg: number | null }>(
+      `SELECT AVG(value_avg) AS avg FROM healthkit_daily
+       WHERE metric = 'resting_hr' AND date > $1 AND date <= $2`,
+      [windowStartIso, asOf]
+    );
+    const baseline = await queryOne<{ avg: number | null }>(
+      `SELECT AVG(value_avg) AS avg FROM healthkit_daily
+       WHERE metric = 'resting_hr' AND date > $1 AND date <= $2`,
+      [baselineStartIso, asOf]
+    );
+    if (last || window?.avg || baseline?.avg) {
+      const deltaBpm = (last?.value_avg != null && baseline?.avg != null)
+        ? Math.round((last.value_avg - baseline.avg) * 10) / 10
+        : null;
+      out.resting_hr = {
+        last: last?.value_avg ?? null,
+        window_avg: window?.avg ?? null,
+        baseline_30d_avg: baseline?.avg ?? null,
+        delta_bpm: deltaBpm,
+      };
+    }
+  }
+
+  if (includes('vo2_max')) {
+    const latest = await queryOne<{ value_avg: number | null; date: string }>(
+      `SELECT value_avg, date::text AS date FROM healthkit_daily
+       WHERE metric = 'vo2_max' AND date <= $1 ORDER BY date DESC LIMIT 1`,
+      [asOf]
+    );
+    const baseline = await queryOne<{ avg: number | null }>(
+      `SELECT AVG(value_avg) AS avg FROM healthkit_daily
+       WHERE metric = 'vo2_max' AND date > $1 AND date <= $2`,
+      [baselineStartIso, asOf]
+    );
+    if (latest?.value_avg || baseline?.avg) {
+      const trend = (latest?.value_avg != null && baseline?.avg != null)
+        ? Math.round((latest.value_avg - baseline.avg) * 10) / 10
+        : null;
+      out.vo2_max = {
+        current: latest?.value_avg ?? null,
+        trend_30d: trend,
+      };
+    }
+  }
+
+  if (includes('activity_today')) {
+    const rows = await query<{ metric: string; value_sum: number | null }>(
+      `SELECT metric, value_sum FROM healthkit_daily
+       WHERE date = $1 AND metric IN ('steps','active_energy','basal_energy','exercise_minutes')`,
+      [asOf]
+    );
+    const byMetric = Object.fromEntries(rows.map(r => [r.metric, r.value_sum]));
+    out.activity_today = {
+      steps: byMetric['steps'] ?? null,
+      active_kcal: byMetric['active_energy'] ?? null,
+      basal_kcal: byMetric['basal_energy'] ?? null,
+      exercise_min: byMetric['exercise_minutes'] ?? null,
+    };
+  }
+
+  if (includes('unlogged_workouts_24h')) {
+    const unlogged = await query<{
+      hk_uuid: string; activity_type: string; start_at: string;
+      duration_s: number; total_energy_kcal: number | null;
+    }>(
+      `SELECT hk_uuid, activity_type, start_at, duration_s, total_energy_kcal
+       FROM healthkit_workouts
+       WHERE source = 'hk_only' AND start_at >= NOW() - interval '24 hours'
+       ORDER BY start_at DESC`
+    );
+    out.unlogged_workouts_24h = unlogged.map(u => ({
+      hk_uuid: u.hk_uuid,
+      activity_type: u.activity_type,
+      start: u.start_at,
+      duration_s: u.duration_s,
+      energy_kcal: u.total_energy_kcal,
+    }));
+  }
+
+  if (includes('data_quality')) {
+    const windowCounts = await query<{ metric: string; count: number }>(
+      `SELECT metric, COUNT(*)::int AS count FROM healthkit_daily
+       WHERE date > $1 AND date <= $2 AND metric IN ('hrv','sleep_asleep','resting_hr','steps')
+       GROUP BY metric`,
+      [windowStartIso, asOf]
+    );
+    const byMetric = Object.fromEntries(windowCounts.map(r => [r.metric, r.count]));
+
+    // Missing metrics: zero rows in the last window_days for a coaching-relevant metric
+    const missing: string[] = [];
+    for (const m of ['hrv', 'sleep_asleep', 'resting_hr', 'steps']) {
+      if (!byMetric[m]) missing.push(m);
+    }
+
+    out.data_quality = {
+      hrv_samples_window: byMetric['hrv'] ?? 0,
+      sleep_nights_window: byMetric['sleep_asleep'] ?? 0,
+      missing_metrics: missing,
+      last_sync_at: status.last_sync_at,
+      last_successful_sync_at: status.last_successful_sync_at,
+    };
+  }
+
+  return toolResult(out);
+}
+
+async function getHealthSeries(args: Record<string, unknown>) {
+  const status = await getHealthKitStatus();
+  if (status.status !== 'connected') return toolResult(notConnectedResponse(status.status));
+
+  const metric = typeof args.metric === 'string' ? args.metric : null;
+  if (!metric || !VALID_SERIES_METRICS.includes(metric as typeof VALID_SERIES_METRICS[number])) {
+    return toolError(`metric must be one of: ${VALID_SERIES_METRICS.join(', ')}`);
+  }
+  const from = typeof args.from === 'string' ? args.from.slice(0, 10) : null;
+  const to = typeof args.to === 'string' ? args.to.slice(0, 10) : new Date().toISOString().slice(0, 10);
+  if (!from) return toolError('from (YYYY-MM-DD) is required');
+  const bucket = args.bucket === 'week' ? 'week' : 'day';
+
+  if (bucket === 'day') {
+    const rows = await query<{
+      date: string; value_min: number | null; value_max: number | null;
+      value_avg: number | null; value_sum: number | null; count: number | null;
+    }>(
+      `SELECT to_char(date, 'YYYY-MM-DD') AS date,
+              value_min, value_max, value_avg, value_sum, count
+       FROM healthkit_daily
+       WHERE metric = $1 AND date >= $2 AND date <= $3
+       ORDER BY date`,
+      [metric, from, to]
+    );
+    return toolResult(rows);
+  }
+
+  // Weekly bucketing (ISO week, Mon-Sun)
+  const rows = await query<{
+    week_start: string; value_min: number | null; value_max: number | null;
+    value_avg: number | null; value_sum: number | null; count: number | null;
+  }>(
+    `SELECT to_char(date_trunc('week', date)::date, 'YYYY-MM-DD') AS week_start,
+            MIN(value_min) AS value_min,
+            MAX(value_max) AS value_max,
+            AVG(value_avg) AS value_avg,
+            SUM(value_sum) AS value_sum,
+            SUM(count) AS count
+     FROM healthkit_daily
+     WHERE metric = $1 AND date >= $2 AND date <= $3
+     GROUP BY date_trunc('week', date)
+     ORDER BY week_start`,
+    [metric, from, to]
+  );
+  return toolResult(rows);
+}
+
+async function getHealthWorkoutsTool(args: Record<string, unknown>) {
+  const status = await getHealthKitStatus();
+  if (status.status !== 'connected') return toolResult(notConnectedResponse(status.status));
+
+  const from = typeof args.from === 'string' ? args.from : null;
+  const to = typeof args.to === 'string' ? args.to : new Date().toISOString();
+  if (!from) return toolError('from (ISO) is required');
+  const sourceArg = (typeof args.source === 'string' ? args.source : 'all') as typeof VALID_WORKOUT_SOURCES[number];
+  if (!VALID_WORKOUT_SOURCES.includes(sourceArg)) {
+    return toolError(`source must be one of: ${VALID_WORKOUT_SOURCES.join(', ')}`);
+  }
+
+  let sql = `SELECT hk_uuid, activity_type,
+                    to_char(start_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS start_at,
+                    to_char(end_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS end_at,
+                    duration_s, total_energy_kcal, total_distance_m,
+                    avg_heart_rate, max_heart_rate,
+                    source_name, source, workout_uuid
+             FROM healthkit_workouts
+             WHERE start_at >= $1::timestamptz AND start_at <= $2::timestamptz`;
+  const params: unknown[] = [from, to];
+  if (sourceArg !== 'all') {
+    params.push(sourceArg);
+    sql += ` AND source = $${params.length}`;
+  }
+  sql += ` ORDER BY start_at DESC`;
+
+  const rows = await query(sql, params);
+  return toolResult(rows);
+}
+
 // ── Tool registry ─────────────────────────────────────────────────────────────
 
 export const tools: MCPTool[] = [
@@ -2292,6 +2615,68 @@ export const tools: MCPTool[] = [
       required: ['sex'],
     },
     execute: getBodyNormRangesTool,
+  },
+
+  // ── HealthKit tools ─────────────────────────────────────────────────────────
+  {
+    name: 'get_health_snapshot',
+    description:
+      'Returns a composite "how are they right now" snapshot from Apple HealthKit: last night sleep (total, REM, deep), HRV (latest + window + 30d baseline + delta %), resting HR (same), VO2 max, today\'s activity rings (steps, active/basal kcal, exercise min), any workouts HK recorded in the last 24h that aren\'t logged in Rebirth (source="hk_only" — this is the adherence/missed-workout signal), and data_quality info. Pass fields=["sleep_last_night","hrv"] to project only specific branches (~120 tokens vs ~500 full). Call once per session or when the user asks about health, training, or recovery. If HealthKit isn\'t connected, returns {status:"not_connected", reason, message}.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        as_of: { type: 'string', description: 'YYYY-MM-DD; defaults to today (UTC).' },
+        window_days: { type: 'number', description: 'Window for window_avg and activity baselines. Default 7, max 90.' },
+        fields: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['sleep_last_night', 'hrv', 'resting_hr', 'vo2_max', 'activity_today', 'unlogged_workouts_24h', 'data_quality'],
+          },
+          description: 'Optional subset of top-level keys to return. Omit for the full snapshot.',
+        },
+      },
+    },
+    execute: getHealthSnapshot,
+  },
+  {
+    name: 'get_health_series',
+    description:
+      'Returns daily (or weekly) aggregate time-series for a single HealthKit metric. Use this for trend questions ("how has my HRV been over 2 weeks?"). Pairs with get_health_snapshot for point-in-time reads.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        metric: {
+          type: 'string',
+          enum: [...VALID_SERIES_METRICS],
+          description: 'Which aggregate to fetch. Sleep metrics report minutes per stage.',
+        },
+        from: { type: 'string', description: 'YYYY-MM-DD inclusive start.' },
+        to: { type: 'string', description: 'YYYY-MM-DD inclusive end (default today).' },
+        bucket: { type: 'string', enum: ['day', 'week'], description: 'Default day.' },
+      },
+      required: ['metric', 'from'],
+    },
+    execute: getHealthSeries,
+  },
+  {
+    name: 'get_health_workouts',
+    description:
+      'Returns HealthKit workout records in a date window. source="hk_only" finds workouts the user did (recorded by Apple Watch / similar) but didn\'t log in Rebirth — this is the reconciliation / missed-workout path for coaching. source="user_logged" = came from Rebirth. source="matched" = Apple Watch workout fuzzy-matched to a Rebirth session. source="all" (default) returns everything.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        from: { type: 'string', description: 'ISO-8601 start (e.g. 2026-04-01T00:00:00Z).' },
+        to: { type: 'string', description: 'ISO-8601 end; defaults to now.' },
+        source: {
+          type: 'string',
+          enum: [...VALID_WORKOUT_SOURCES],
+          description: 'Filter by source tag. Default "all".',
+        },
+      },
+      required: ['from'],
+    },
+    execute: getHealthWorkoutsTool,
   },
 ];
 

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -113,18 +113,25 @@ class SyncEngine {
         workout_exercises: import('@/db/local').LocalWorkoutExercise[];
         workout_sets: import('@/db/local').LocalWorkoutSet[];
         bodyweight_logs: import('@/db/local').LocalBodyweightLog[];
+        exercises?: import('@/db/local').LocalExercise[];
         deleted: { workouts: string[]; workout_exercises: string[]; workout_sets: string[]; bodyweight_logs: string[] };
         pulled_at: string;
       };
 
-      // Upsert — server wins for conflicts (single-user, server is authoritative)
-      // Use single Dexie transaction to avoid iOS WebKit IndexedDB limits
-      await db.transaction('rw', db.workouts, db.workout_exercises, db.workout_sets, db.bodyweight_logs, async () => {
-        if (data.workouts.length) await db.workouts.bulkPut(data.workouts.map(r => ({ ...r, _synced: true })));
-        if (data.workout_exercises.length) await db.workout_exercises.bulkPut(data.workout_exercises.map(r => ({ ...r, _synced: true })));
-        if (data.workout_sets.length) await db.workout_sets.bulkPut(data.workout_sets.map(r => ({ ...r, _synced: true })));
-        if (data.bodyweight_logs.length) await db.bodyweight_logs.bulkPut(data.bodyweight_logs.map(r => ({ ...r, _synced: true })));
-      });
+      // Upsert — server wins for conflicts (single-user, server is authoritative).
+      // Exercises MUST upsert in the same transaction as workout_exercises so the
+      // catalog can never fall behind the UUIDs that workout rows reference.
+      await db.transaction(
+        'rw',
+        [db.workouts, db.workout_exercises, db.workout_sets, db.bodyweight_logs, db.exercises],
+        async () => {
+          if (data.exercises?.length) await db.exercises.bulkPut(data.exercises);
+          if (data.workouts.length) await db.workouts.bulkPut(data.workouts.map(r => ({ ...r, _synced: true })));
+          if (data.workout_exercises.length) await db.workout_exercises.bulkPut(data.workout_exercises.map(r => ({ ...r, _synced: true })));
+          if (data.workout_sets.length) await db.workout_sets.bulkPut(data.workout_sets.map(r => ({ ...r, _synced: true })));
+          if (data.bodyweight_logs.length) await db.bodyweight_logs.bulkPut(data.bodyweight_logs.map(r => ({ ...r, _synced: true })));
+        },
+      );
 
       // Apply server-side deletes
       if (data.deleted) {


### PR DESCRIPTION
## Summary
- Full Apple HealthKit integration: reads (daily aggregates + anchored sleep + anchored workouts), writes (nutrition meals + InBody body comp), and 3 MCP tools for coaching access (`get_health_snapshot`, `get_health_series`, `get_health_workouts`).
- Fixes the dead "Open Settings" CTA on the workout page and adds a real Settings section with Connect / Sync now / Manage in Apple Health.
- New migration `017_healthkit.sql` creates 4 tables and has already been applied on the Neon DB.

## Test plan
- [x] `npx vitest run` — 766 / 766 passing
- [x] TS type check clean on all new code
- [x] Device build + install on iPhone 17 succeeds
- [x] Crash on launch fixed (root cause: illegal NSPredicate key-path in HealthKit query — traced via crash report, documented in commit)
- [ ] Tap Rebirth → Settings → "Connect to Apple Health" → verify the permission sheet lists all types and sync populates `healthkit_daily` / `healthkit_workouts`
- [ ] MCP `get_health_snapshot` returns composite with real sleep / HRV / activity data

🤖 Generated with [Claude Code](https://claude.com/claude-code)