### PR TITLE
feat: migrate /wellbeing (3 tabs) to local-first

### DIFF
--- a/src/app/wellbeing/page.tsx
+++ b/src/app/wellbeing/page.tsx
@@ -1,12 +1,28 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
 import { ChevronLeft, Trash2 } from 'lucide-react';
 import Link from 'next/link';
-import type { WellbeingLog, DysphoriaLog, ClothesTestLog } from '@/types';
 import { rebirthJsonHeaders } from '@/lib/api/headers';
 import { apiBase } from '@/lib/api/client';
+import { useWellbeingLogs, useDysphoriaLogs, useClothesTestLogs } from '@/lib/useLocalDB-wellbeing';
+import {
+  logWellbeing,
+  deleteWellbeingLog,
+  logDysphoria,
+  deleteDysphoriaLog,
+  logClothesTest,
+  deleteClothesTestLog,
+} from '@/lib/mutations-wellbeing';
+
+// Local-first /wellbeing across three tabs (Daily, Journal, Clothes Test).
+// Each tab reads from a useLiveQuery hook and writes through mutations-wellbeing.
+//
+// Correlation summary (avg mood / energy / workout count for the last 30
+// days) still calls /api/wellbeing/correlation — it's a server-aggregated
+// JOIN against workouts that's not worth porting to client-side aggregation
+// for the secondary visualization. Could move to a client aggregator
+// alongside the feed migration.
 
 type Tab = 'daily' | 'journal' | 'clothes';
 
@@ -58,8 +74,7 @@ function ScalePicker({
 // ===== Daily Tab =====
 
 function DailyTab() {
-  const [logs, setLogs] = useState<WellbeingLog[]>([]);
-  const [loading, setLoading] = useState(true);
+  const logs = useWellbeingLogs(30);
   const [mood, setMood] = useState<number | null>(null);
   const [energy, setEnergy] = useState<number | null>(null);
   const [sleep, setSleep] = useState('');
@@ -71,27 +86,7 @@ function DailyTab() {
     workout_count: number;
   } | null>(null);
 
-  const deleteWellbeingMut = useMutation({
-    mutationFn: (uuid: string) =>
-      fetch(`${apiBase()}/api/wellbeing/${uuid}`, { method: 'DELETE', headers: rebirthJsonHeaders() }).then((r) => {
-        if (!r.ok) throw new Error('Delete failed');
-      }),
-    onMutate: (uuid) => {
-      const prev = logs;
-      setLogs((l) => l.filter((x) => x.uuid !== uuid));
-      return { prev };
-    },
-    onError: (_e, _u, ctx) => {
-      if (ctx?.prev) setLogs(ctx.prev);
-    },
-  });
-
   useEffect(() => {
-    fetch(`${apiBase()}/api/wellbeing?limit=30`, { headers: rebirthJsonHeaders() })
-      .then(r => r.json())
-      .then((data: WellbeingLog[]) => { setLogs(data); setLoading(false); })
-      .catch(() => setLoading(false));
-
     fetch(`${apiBase()}/api/wellbeing/correlation`, { headers: rebirthJsonHeaders() })
       .then(r => r.ok ? r.json() : null)
       .then(data => { if (data) setCorrelation(data); })
@@ -102,24 +97,16 @@ function DailyTab() {
     if (!mood && !energy) return;
     setSaving(true);
     try {
-      const res = await fetch(`${apiBase()}/api/wellbeing`, {
-        method: 'POST',
-        headers: rebirthJsonHeaders(),
-        body: JSON.stringify({
-          mood: mood ?? undefined,
-          energy: energy ?? undefined,
-          sleep_hours: sleep ? parseFloat(sleep) : undefined,
-          notes: notes || undefined,
-        }),
+      await logWellbeing({
+        mood: mood ?? null,
+        energy: energy ?? null,
+        sleep_hours: sleep ? parseFloat(sleep) : null,
+        notes: notes || null,
       });
-      if (res.ok) {
-        const log: WellbeingLog = await res.json();
-        setLogs(prev => [log, ...prev]);
-        setMood(null);
-        setEnergy(null);
-        setSleep('');
-        setNotes('');
-      }
+      setMood(null);
+      setEnergy(null);
+      setSleep('');
+      setNotes('');
     } finally {
       setSaving(false);
     }
@@ -199,7 +186,7 @@ function DailyTab() {
       </div>
 
       {/* History */}
-      {!loading && logs.length > 0 && (
+      {logs.length > 0 && (
         <div>
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">History</p>
           <div className="ios-section">
@@ -218,7 +205,7 @@ function DailyTab() {
                 </div>
                 <span className="text-xs text-muted-foreground mr-3 shrink-0">{formatDate(log.logged_at)}</span>
                 <button
-                  onClick={() => deleteWellbeingMut.mutate(log.uuid)}
+                  onClick={() => deleteWellbeingLog(log.uuid)}
                   className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center shrink-0"
                 >
                   <Trash2 className="h-4 w-4" />
@@ -228,7 +215,7 @@ function DailyTab() {
           </div>
         </div>
       )}
-      {!loading && logs.length === 0 && (
+      {logs.length === 0 && (
         <p className="text-xs text-muted-foreground px-1">No entries yet.</p>
       )}
     </div>
@@ -238,49 +225,18 @@ function DailyTab() {
 // ===== Journal Tab (Dysphoria/Euphoria) =====
 
 function JournalTab() {
-  const [logs, setLogs] = useState<DysphoriaLog[]>([]);
-  const [loading, setLoading] = useState(true);
+  const logs = useDysphoriaLogs(60);
   const [scale, setScale] = useState<number | null>(null);
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
-
-  const deleteDysphoriaMut = useMutation({
-    mutationFn: (uuid: string) =>
-      fetch(`${apiBase()}/api/dysphoria/${uuid}`, { method: 'DELETE', headers: rebirthJsonHeaders() }).then((r) => {
-        if (!r.ok) throw new Error('Delete failed');
-      }),
-    onMutate: (uuid) => {
-      const prev = logs;
-      setLogs((l) => l.filter((x) => x.uuid !== uuid));
-      return { prev };
-    },
-    onError: (_e, _u, ctx) => {
-      if (ctx?.prev) setLogs(ctx.prev);
-    },
-  });
-
-  useEffect(() => {
-    fetch(`${apiBase()}/api/dysphoria?limit=60`, { headers: rebirthJsonHeaders() })
-      .then(r => r.json())
-      .then((data: DysphoriaLog[]) => { setLogs(data); setLoading(false); })
-      .catch(() => setLoading(false));
-  }, []);
 
   const handleLog = async () => {
     if (!scale) return;
     setSaving(true);
     try {
-      const res = await fetch(`${apiBase()}/api/dysphoria`, {
-        method: 'POST',
-        headers: rebirthJsonHeaders(),
-        body: JSON.stringify({ scale, note: note || undefined }),
-      });
-      if (res.ok) {
-        const log: DysphoriaLog = await res.json();
-        setLogs(prev => [log, ...prev]);
-        setScale(null);
-        setNote('');
-      }
+      await logDysphoria({ scale, note: note || null });
+      setScale(null);
+      setNote('');
     } finally {
       setSaving(false);
     }
@@ -316,7 +272,7 @@ function JournalTab() {
         </button>
       </div>
 
-      {!loading && logs.length > 0 && (
+      {logs.length > 0 && (
         <div>
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">History</p>
           <div className="ios-section">
@@ -334,7 +290,7 @@ function JournalTab() {
                 </div>
                 <span className="text-xs text-muted-foreground mr-3 shrink-0">{formatDate(log.logged_at)}</span>
                 <button
-                  onClick={() => deleteDysphoriaMut.mutate(log.uuid)}
+                  onClick={() => deleteDysphoriaLog(log.uuid)}
                   className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center shrink-0"
                 >
                   <Trash2 className="h-4 w-4" />
@@ -344,7 +300,7 @@ function JournalTab() {
           </div>
         </div>
       )}
-      {!loading && logs.length === 0 && (
+      {logs.length === 0 && (
         <p className="text-xs text-muted-foreground px-1">No journal entries yet.</p>
       )}
     </div>
@@ -354,58 +310,27 @@ function JournalTab() {
 // ===== Clothes Test Tab =====
 
 function ClothesTestTab() {
-  const [logs, setLogs] = useState<ClothesTestLog[]>([]);
-  const [loading, setLoading] = useState(true);
+  const logs = useClothesTestLogs(50);
   const [outfit, setOutfit] = useState('');
   const [comfort, setComfort] = useState<number | null>(null);
   const [euphoria, setEuphoria] = useState<number | null>(null);
   const [notes, setNotes] = useState('');
   const [saving, setSaving] = useState(false);
 
-  const deleteClothesMut = useMutation({
-    mutationFn: (uuid: string) =>
-      fetch(`${apiBase()}/api/clothes-test/${uuid}`, { method: 'DELETE', headers: rebirthJsonHeaders() }).then((r) => {
-        if (!r.ok) throw new Error('Delete failed');
-      }),
-    onMutate: (uuid) => {
-      const prev = logs;
-      setLogs((l) => l.filter((x) => x.uuid !== uuid));
-      return { prev };
-    },
-    onError: (_e, _u, ctx) => {
-      if (ctx?.prev) setLogs(ctx.prev);
-    },
-  });
-
-  useEffect(() => {
-    fetch(`${apiBase()}/api/clothes-test?limit=50`, { headers: rebirthJsonHeaders() })
-      .then(r => r.json())
-      .then((data: ClothesTestLog[]) => { setLogs(data); setLoading(false); })
-      .catch(() => setLoading(false));
-  }, []);
-
   const handleLog = async () => {
     if (!outfit.trim()) return;
     setSaving(true);
     try {
-      const res = await fetch(`${apiBase()}/api/clothes-test`, {
-        method: 'POST',
-        headers: rebirthJsonHeaders(),
-        body: JSON.stringify({
-          outfit_description: outfit.trim(),
-          comfort_rating: comfort ?? undefined,
-          euphoria_rating: euphoria ?? undefined,
-          notes: notes || undefined,
-        }),
+      await logClothesTest({
+        outfit_description: outfit.trim(),
+        comfort_rating: comfort ?? null,
+        euphoria_rating: euphoria ?? null,
+        notes: notes || null,
       });
-      if (res.ok) {
-        const log: ClothesTestLog = await res.json();
-        setLogs(prev => [log, ...prev]);
-        setOutfit('');
-        setComfort(null);
-        setEuphoria(null);
-        setNotes('');
-      }
+      setOutfit('');
+      setComfort(null);
+      setEuphoria(null);
+      setNotes('');
     } finally {
       setSaving(false);
     }
@@ -455,7 +380,7 @@ function ClothesTestTab() {
         </button>
       </div>
 
-      {!loading && logs.length > 0 && (
+      {logs.length > 0 && (
         <div>
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">History</p>
           <div className="ios-section">
@@ -474,7 +399,7 @@ function ClothesTestTab() {
                 </div>
                 <span className="text-xs text-muted-foreground mr-3 shrink-0">{formatDate(log.logged_at)}</span>
                 <button
-                  onClick={() => deleteClothesMut.mutate(log.uuid)}
+                  onClick={() => deleteClothesTestLog(log.uuid)}
                   className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center shrink-0"
                 >
                   <Trash2 className="h-4 w-4" />
@@ -484,7 +409,7 @@ function ClothesTestTab() {
           </div>
         </div>
       )}
-      {!loading && logs.length === 0 && (
+      {logs.length === 0 && (
         <p className="text-xs text-muted-foreground px-1">No clothes tests yet.</p>
       )}
     </div>

--- a/src/lib/mutations-wellbeing.test.ts
+++ b/src/lib/mutations-wellbeing.test.ts
@@ -1,0 +1,99 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { db } from '@/db/local';
+import {
+  logWellbeing,
+  deleteWellbeingLog,
+  logDysphoria,
+  deleteDysphoriaLog,
+  logClothesTest,
+  deleteClothesTestLog,
+} from './mutations-wellbeing';
+
+vi.mock('@/lib/sync', () => ({
+  syncEngine: { schedulePush: vi.fn() },
+}));
+
+describe('mutations-wellbeing', () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.wellbeing_logs.clear(),
+      db.dysphoria_logs.clear(),
+      db.clothes_test_logs.clear(),
+    ]);
+  });
+
+  describe('wellbeing logs', () => {
+    it('logWellbeing inserts with sync metadata + trims notes + sets logged_at', async () => {
+      const log = await logWellbeing({
+        mood: 4,
+        energy: 3,
+        sleep_hours: 7.5,
+        notes: '  good day  ',
+      });
+
+      const stored = await db.wellbeing_logs.get(log.uuid);
+      expect(stored).toBeDefined();
+      expect(stored!.mood).toBe(4);
+      expect(stored!.energy).toBe(3);
+      expect(stored!.sleep_hours).toBe(7.5);
+      expect(stored!.notes).toBe('good day');
+      expect(stored!._synced).toBe(false);
+      expect(stored!._deleted).toBe(false);
+      expect(stored!.logged_at).toBeTruthy();
+    });
+
+    it('logWellbeing normalizes empty/whitespace notes to null', async () => {
+      const log = await logWellbeing({ mood: 4, notes: '   ' });
+      const stored = await db.wellbeing_logs.get(log.uuid);
+      expect(stored!.notes).toBeNull();
+    });
+
+    it('deleteWellbeingLog soft-deletes for sync', async () => {
+      const log = await logWellbeing({ mood: 5 });
+      await deleteWellbeingLog(log.uuid);
+      const stored = await db.wellbeing_logs.get(log.uuid);
+      expect(stored!._deleted).toBe(true);
+      expect(stored!._synced).toBe(false);
+    });
+  });
+
+  describe('dysphoria logs', () => {
+    it('logDysphoria persists scale + trimmed note', async () => {
+      const log = await logDysphoria({ scale: 7, note: '  felt good  ' });
+      const stored = await db.dysphoria_logs.get(log.uuid);
+      expect(stored!.scale).toBe(7);
+      expect(stored!.note).toBe('felt good');
+    });
+
+    it('deleteDysphoriaLog soft-deletes', async () => {
+      const log = await logDysphoria({ scale: 5 });
+      await deleteDysphoriaLog(log.uuid);
+      const stored = await db.dysphoria_logs.get(log.uuid);
+      expect(stored!._deleted).toBe(true);
+    });
+  });
+
+  describe('clothes test logs', () => {
+    it('logClothesTest persists outfit + ratings + notes', async () => {
+      const log = await logClothesTest({
+        outfit_description: '  black dress  ',
+        comfort_rating: 8,
+        euphoria_rating: 9,
+        notes: 'felt amazing',
+      });
+      const stored = await db.clothes_test_logs.get(log.uuid);
+      expect(stored!.outfit_description).toBe('black dress');
+      expect(stored!.comfort_rating).toBe(8);
+      expect(stored!.euphoria_rating).toBe(9);
+      expect(stored!.notes).toBe('felt amazing');
+    });
+
+    it('deleteClothesTestLog soft-deletes', async () => {
+      const log = await logClothesTest({ outfit_description: 'jeans' });
+      await deleteClothesTestLog(log.uuid);
+      const stored = await db.clothes_test_logs.get(log.uuid);
+      expect(stored!._deleted).toBe(true);
+    });
+  });
+});

--- a/src/lib/mutations-wellbeing.ts
+++ b/src/lib/mutations-wellbeing.ts
@@ -1,0 +1,109 @@
+'use client';
+
+import { db } from '@/db/local';
+import { syncEngine } from '@/lib/sync';
+import { uuid as genUUID } from '@/lib/uuid';
+import type {
+  LocalWellbeingLog,
+  LocalDysphoriaLog,
+  LocalClothesTestLog,
+} from '@/db/local';
+
+// Mutations for the three wellbeing tabs:
+// - wellbeing_logs (mood / energy / sleep / stress)
+// - dysphoria_logs (gender expression scale)
+// - clothes_test_logs (outfit comfort + euphoria)
+//
+// All three follow the same single-table append-or-tombstone shape:
+// no parent/child cascades, no exotic fields.
+
+function now() {
+  return Date.now();
+}
+
+function syncMeta() {
+  return { _synced: false as const, _updated_at: now(), _deleted: false as const };
+}
+
+// ─── Wellbeing logs ──────────────────────────────────────────────────────────
+
+export async function logWellbeing(opts: {
+  mood?: number | null;
+  energy?: number | null;
+  sleep_hours?: number | null;
+  sleep_quality?: number | null;
+  stress?: number | null;
+  notes?: string | null;
+}): Promise<LocalWellbeingLog> {
+  const log: LocalWellbeingLog = {
+    uuid: genUUID(),
+    logged_at: new Date().toISOString(),
+    mood: opts.mood ?? null,
+    energy: opts.energy ?? null,
+    sleep_hours: opts.sleep_hours ?? null,
+    sleep_quality: opts.sleep_quality ?? null,
+    stress: opts.stress ?? null,
+    notes: opts.notes?.trim() || null,
+    ...syncMeta(),
+  };
+  await db.wellbeing_logs.add(log);
+  syncEngine.schedulePush();
+  return log;
+}
+
+export async function deleteWellbeingLog(uuid: string): Promise<void> {
+  await db.wellbeing_logs.update(uuid, { _deleted: true, _synced: false, _updated_at: now() });
+  syncEngine.schedulePush();
+}
+
+// ─── Dysphoria logs ──────────────────────────────────────────────────────────
+
+export async function logDysphoria(opts: {
+  scale: number;
+  note?: string | null;
+}): Promise<LocalDysphoriaLog> {
+  const log: LocalDysphoriaLog = {
+    uuid: genUUID(),
+    logged_at: new Date().toISOString(),
+    scale: opts.scale,
+    note: opts.note?.trim() || null,
+    ...syncMeta(),
+  };
+  await db.dysphoria_logs.add(log);
+  syncEngine.schedulePush();
+  return log;
+}
+
+export async function deleteDysphoriaLog(uuid: string): Promise<void> {
+  await db.dysphoria_logs.update(uuid, { _deleted: true, _synced: false, _updated_at: now() });
+  syncEngine.schedulePush();
+}
+
+// ─── Clothes test logs ───────────────────────────────────────────────────────
+
+export async function logClothesTest(opts: {
+  outfit_description: string;
+  comfort_rating?: number | null;
+  euphoria_rating?: number | null;
+  notes?: string | null;
+  photo_url?: string | null;
+}): Promise<LocalClothesTestLog> {
+  const log: LocalClothesTestLog = {
+    uuid: genUUID(),
+    logged_at: new Date().toISOString(),
+    outfit_description: opts.outfit_description.trim(),
+    photo_url: opts.photo_url ?? null,
+    comfort_rating: opts.comfort_rating ?? null,
+    euphoria_rating: opts.euphoria_rating ?? null,
+    notes: opts.notes?.trim() || null,
+    ...syncMeta(),
+  };
+  await db.clothes_test_logs.add(log);
+  syncEngine.schedulePush();
+  return log;
+}
+
+export async function deleteClothesTestLog(uuid: string): Promise<void> {
+  await db.clothes_test_logs.update(uuid, { _deleted: true, _synced: false, _updated_at: now() });
+  syncEngine.schedulePush();
+}

--- a/src/lib/useLocalDB-wellbeing.ts
+++ b/src/lib/useLocalDB-wellbeing.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db } from '@/db/local';
+import type {
+  LocalWellbeingLog,
+  LocalDysphoriaLog,
+  LocalClothesTestLog,
+} from '@/db/local';
+
+// Reactive hooks for the three wellbeing tabs. Each returns
+// most-recent-first, capped to a sensible UI window.
+
+export function useWellbeingLogs(limit = 30): LocalWellbeingLog[] {
+  return useLiveQuery(
+    () =>
+      db.wellbeing_logs
+        .filter(l => !l._deleted)
+        .reverse()
+        .sortBy('logged_at')
+        .then(rows => rows.slice(0, limit)),
+    [limit],
+    [],
+  );
+}
+
+export function useDysphoriaLogs(limit = 60): LocalDysphoriaLog[] {
+  return useLiveQuery(
+    () =>
+      db.dysphoria_logs
+        .filter(l => !l._deleted)
+        .reverse()
+        .sortBy('logged_at')
+        .then(rows => rows.slice(0, limit)),
+    [limit],
+    [],
+  );
+}
+
+export function useClothesTestLogs(limit = 50): LocalClothesTestLog[] {
+  return useLiveQuery(
+    () =>
+      db.clothes_test_logs
+        .filter(l => !l._deleted)
+        .reverse()
+        .sortBy('logged_at')
+        .then(rows => rows.slice(0, limit)),
+    [limit],
+    [],
+  );
+}


### PR DESCRIPTION
## Summary

Stacked on PR #16. Migrates the /wellbeing page across all three tabs (Daily / Journal / Clothes Test) to local-first reads + writes. Demonstrates the foundation pattern generalizing to non-hierarchical single-table domains, contrasting with the plans hierarchy in #15-#16.

**User-visible changes on /wellbeing:**
- All three tabs render their history instantly from Dexie. No fetch round-trip on tab switch.
- Optimistic updates free — the previous code had hand-rolled onMutate/onError rollback for every delete; that goes away because useLiveQuery picks up the soft-delete immediately.
- MCP-driven additions/edits propagate within ~15s polling or instantly on app foreground.

**What this PR adds:**
- src/lib/mutations-wellbeing.ts — log + delete for wellbeing_logs, dysphoria_logs, clothes_test_logs. Whitespace-only inputs normalize to null for cleaner server round-trip.
- src/lib/useLocalDB-wellbeing.ts — useWellbeingLogs(limit=30), useDysphoriaLogs(limit=60), useClothesTestLogs(limit=50). Each list reads most-recent-first.
- 7 new tests covering log + soft-delete + whitespace normalization across all three tables.

**Carried over (still uses API):**
- /api/wellbeing/correlation — secondary visualization (avg mood / energy / workout count last 30 days). Server JOINs wellbeing_logs against workouts to compute. Client-side aggregation is overkill for a single summary card; can move alongside the feed migration if we want.

## Test Coverage

- 788 tests pass (was 781, +7).
- TypeScript: 44 pre-existing errors, 44 after — no new regressions.
- next build: clean.

## Test plan

- [x] All 788 vitest tests pass
- [x] Type check clean
- [x] Build clean
- [ ] Manual /wellbeing verification on TestFlight after merging #14-#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)