### PR TITLE
chore(nav): swap History/Exercises in dock for HRT/Measurements

### DIFF
--- a/src/app/workout/page.tsx
+++ b/src/app/workout/page.tsx
@@ -22,7 +22,7 @@ import {
 import { consumeScheduleTap } from '@/lib/workout-schedule';
 import { HealthSection } from '@/components/HealthSection';
 import Link from 'next/link';
-import { Check, ChevronDown, ChevronRight, Clock, GripVertical, Plus, Search, Settings, X } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, ClipboardList, Clock, Dumbbell, GripVertical, Plus, Search, X } from 'lucide-react';
 import type { WorkoutPlan, WorkoutRoutine, WorkoutRoutineExercise, WorkoutRoutineSet, Exercise } from '@/types';
 import { formatTime, calcCompletedSets, calcTotalVolume } from './workout-utils';
 import { uuid as genUUID } from '@/lib/uuid';
@@ -1381,7 +1381,7 @@ export default function WorkoutPage() {
       <main className="tab-content bg-background overflow-y-auto">
         <div className="px-4 pt-safe pb-4 flex items-center justify-between">
           <h1 className="text-2xl font-bold">Workout</h1>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1">
             <Link
               href="/history"
               className="flex items-center justify-center text-muted-foreground min-h-[44px] min-w-[44px]"
@@ -1390,11 +1390,18 @@ export default function WorkoutPage() {
               <Clock className="h-5 w-5" strokeWidth={1.75} />
             </Link>
             <Link
-              href="/plans"
-              className="flex items-center gap-1.5 text-sm text-primary font-medium min-h-[44px]"
+              href="/exercises"
+              className="flex items-center justify-center text-muted-foreground min-h-[44px] min-w-[44px]"
+              aria-label="Exercises"
             >
-              <Settings className="h-4 w-4" />
-              Manage
+              <Dumbbell className="h-5 w-5" strokeWidth={1.75} />
+            </Link>
+            <Link
+              href="/plans"
+              className="flex items-center justify-center text-muted-foreground min-h-[44px] min-w-[44px]"
+              aria-label="Manage routines"
+            >
+              <ClipboardList className="h-5 w-5" strokeWidth={1.75} />
             </Link>
           </div>
         </div>

--- a/src/components/TabBar.test.ts
+++ b/src/components/TabBar.test.ts
@@ -8,9 +8,9 @@ import { describe, it, expect } from 'vitest';
 /** Main dock tabs (settings is a separate control above the row in TabBar.tsx). */
 const tabs = [
   { href: '/feed', label: 'Feed' },
-  { href: '/history', label: 'History' },
+  { href: '/hrt', label: 'HRT' },
   { href: '/workout', label: 'Workout' },
-  { href: '/exercises', label: 'Exercises' },
+  { href: '/measurements', label: 'Measure' },
   { href: '/nutrition', label: 'Nutrition' },
 ];
 
@@ -32,9 +32,9 @@ describe('tabs configuration', () => {
   it('includes all required top-level routes', () => {
     const hrefs = tabs.map(t => t.href);
     expect(hrefs).toContain('/feed');
-    expect(hrefs).toContain('/history');
     expect(hrefs).toContain('/workout');
-    expect(hrefs).toContain('/exercises');
+    expect(hrefs).toContain('/hrt');
+    expect(hrefs).toContain('/measurements');
     expect(hrefs).toContain('/nutrition');
   });
 

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -3,13 +3,14 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
-import { BarChart2, Plus, Dumbbell, Utensils } from 'lucide-react';
+import { BarChart2, Plus, Pill, Ruler, Utensils } from 'lucide-react';
 import { prefetchMainTabData } from '@/lib/api/prefetch';
 
 const tabs = [
   { href: '/feed', label: 'Feed', icon: BarChart2 },
+  { href: '/hrt', label: 'HRT', icon: Pill },
   { href: '/workout', label: 'Workout', icon: Plus },
-  { href: '/exercises', label: 'Exercises', icon: Dumbbell },
+  { href: '/measurements', label: 'Measure', icon: Ruler },
   { href: '/nutrition', label: 'Nutrition', icon: Utensils },
 ];
 


### PR DESCRIPTION
## Summary

- Dock tabs now show **HRT** and **Measurements** in place of History and Exercises — the daily-trackers that benefit most from one-tap reach.
- The displaced routes (History, Exercises) move into icon-only links in the workout page header, joining the existing Plans link which switches from a labelled "Manage" pill to a ClipboardList icon to match.

## Test plan

- [x] \`bun test src/components/TabBar.test.ts\` → 12 pass / 0 fail
- [x] Lint clean on changed files
- [ ] Confirm dock on real device shows Feed / HRT / Workout / Measure / Nutrition
- [ ] Confirm workout header has History (Clock), Exercises (Dumbbell), Plans (ClipboardList) icon links

🤖 Generated with [Claude Code](https://claude.com/claude-code)