### PR TITLE
chore(measurements): drop legacy 'shoulders' alias from read path

### DIFF
--- a/src/app/measurements/measurements.test.ts
+++ b/src/app/measurements/measurements.test.ts
@@ -216,7 +216,7 @@ describe('chart data derivation', () => {
 
 describe('site alias resolution', () => {
   const SITE_ALIASES: Record<SiteKey, readonly string[]> = {
-    shoulder_width: ['shoulder_width', 'shoulders'],
+    shoulder_width: ['shoulder_width'],
     waist:          ['waist'],
     hips:           ['hips', 'hip'],
     upper_arm:      ['upper_arm', 'left_arm', 'right_arm', 'left_bicep', 'right_bicep'],
@@ -257,11 +257,15 @@ describe('site alias resolution', () => {
     expect(siteGroup('neck')).toBeNull();
     expect(siteGroup('left_calf')).toBeNull();
     expect(siteGroup('abdomen')).toBeNull();
+    // The legacy 'shoulders' literal was removed from the alias list after
+    // the v0.1.2 backfill renamed all DB rows to 'shoulder_width'. New writes
+    // are normalized at the MCP write boundary, so the read path no longer
+    // needs to recognize the legacy literal.
+    expect(siteGroup('shoulders')).toBeNull();
   });
 
-  it('maps legacy shoulders site key to shoulder_width tab', () => {
+  it('canonical shoulder_width key maps to itself', () => {
     expect(siteGroup('shoulder_width')).toBe('shoulder_width');
-    expect(siteGroup('shoulders')).toBe('shoulder_width');
   });
 
   it('chart filter for upper_arm finds left_bicep rows (regression: previously filtered to zero)', () => {
@@ -349,5 +353,45 @@ describe('site alias resolution', () => {
       .sort((a, b) => a.measured_at.localeCompare(b.measured_at))
       .map(({ sum, count }) => Math.round((sum / count) * 10) / 10);
     expect(points).toEqual([28.0, 30.6]);
+  });
+});
+
+// ===== MEASUREMENT_SITE_MAP write-side normalization =====
+// Mirrors src/lib/mcp-tools.ts:MEASUREMENT_SITE_MAP. The map normalizes
+// incoming MCP `update_body_comp` field names to the canonical site stored
+// in measurement_logs.site. The legacy `shoulders` key is normalized to
+// `shoulder_width` so external callers using the old MCP schema can't
+// reintroduce orphan rows after the v0.1.2 rename.
+
+describe('MEASUREMENT_SITE_MAP write-side normalization', () => {
+  const MEASUREMENT_SITE_MAP: Record<string, string> = {
+    chest: 'chest',
+    waist: 'waist',
+    hips: 'hips',
+    neck: 'neck',
+    shoulder_width: 'shoulder_width',
+    shoulders: 'shoulder_width',
+    abdomen: 'abdomen',
+    left_arm: 'left_bicep',
+    right_arm: 'right_bicep',
+    left_forearm: 'left_forearm',
+    right_forearm: 'right_forearm',
+    left_thigh: 'left_thigh',
+    right_thigh: 'right_thigh',
+    left_calf: 'left_calf',
+    right_calf: 'right_calf',
+  };
+
+  it('normalizes legacy shoulders key to shoulder_width', () => {
+    expect(MEASUREMENT_SITE_MAP.shoulders).toBe('shoulder_width');
+  });
+
+  it('preserves canonical shoulder_width key', () => {
+    expect(MEASUREMENT_SITE_MAP.shoulder_width).toBe('shoulder_width');
+  });
+
+  it('keeps left/right arm keys mapping to bicep convention', () => {
+    expect(MEASUREMENT_SITE_MAP.left_arm).toBe('left_bicep');
+    expect(MEASUREMENT_SITE_MAP.right_arm).toBe('right_bicep');
   });
 });

--- a/src/app/measurements/page.tsx
+++ b/src/app/measurements/page.tsx
@@ -41,7 +41,7 @@ const SITE_COLORS: Record<SiteKey, string> = {
 // right_arm/left_thigh/right_thigh. The chart/snapshot needs to surface all of
 // them under the matching UI tab.
 const SITE_ALIASES: Record<SiteKey, readonly string[]> = {
-  shoulder_width: ['shoulder_width', 'shoulders'],
+  shoulder_width: ['shoulder_width'],
   waist:          ['waist'],
   hips:           ['hips', 'hip'],
   upper_arm:      ['upper_arm', 'left_arm', 'right_arm', 'left_bicep', 'right_bicep'],

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -39,6 +39,11 @@ const MEASUREMENT_SITE_MAP: Record<string, string> = {
   hips: 'hips',
   neck: 'neck',
   shoulder_width: 'shoulder_width',
+  // Legacy alias: external MCP callers that still send `shoulders` get
+  // normalized to the canonical site key at write time. Once the alias has
+  // a long-enough zero-hit window, drop this line and tighten the test in
+  // measurements.test.ts.
+  shoulders: 'shoulder_width',
   abdomen: 'abdomen',
   left_arm: 'left_bicep',
   right_arm: 'right_bicep',


### PR DESCRIPTION
## Summary

Removes the legacy \`'shoulders'\` literal from the SITE_ALIASES read path. The v0.1.2 backfill (PR #25) renamed every DB row from \`site='shoulders'\` to \`site='shoulder_width'\` — verified now, 0 rows with the legacy literal, 33 with the canonical key.

To stop the legacy literal from coming back via stale external MCP integrations, adds \`shoulders\` → \`shoulder_width\` to \`MEASUREMENT_SITE_MAP\`. Defense-at-the-boundary: if anything still posts \`shoulders\` to \`update_body_comp\`, it normalizes to the canonical key at write time. Read path stays clean.

## Data path audit

Verified all measurement-site write paths:
- **UI form** (\`/measurements/page.tsx\`) writes \`site: site.key\` — keys are constrained to SITES, can't write \`'shoulders'\`
- **MCP \`update_body_comp\`** schema accepts only \`shoulder_width\`. New: legacy \`shoulders\` field gets normalized to \`shoulder_width\` via MEASUREMENT_SITE_MAP at write time
- **InBody auto-insert** writes \`left_bicep\`/\`right_bicep\`/\`left_thigh\`/\`right_thigh\` — never \`shoulders\`
- **Direct API POST \`/api/measurements\`** is open to any string, but you control all clients

DB state: \`SELECT COUNT(*) WHERE site='shoulders'\` = 0; \`SELECT COUNT(*) WHERE site='shoulder_width'\` = 33.

## Test changes

- \`siteGroup('shoulders')\` is back in the null-set (where it was before PR #25's rename added the alias), with an explanatory comment
- New \`describe('MEASUREMENT_SITE_MAP write-side normalization')\` mirrors the MCP map and asserts the legacy normalization holds

## Test plan
- [x] 806/806 tests pass (38 files)
- [x] Lint clean
- [x] DB confirmed at 0 \`'shoulders'\` rows before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)