### PR TITLE
feat(nutrition): hydration + day-notes on Today, kill legacy subtab (v0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Rebirth are documented here.
 
+## [0.2.2] - 2026-05-01
+
+### Added
+- **Hydration + day-notes editing on `/nutrition/today`.** New section above the "Mark day reviewed" CTA shows your hydration in ml (with +250 / +500 / +750 quick-add buttons sized to common pours) and a free-text notes textarea. Both auto-save with a 600ms debounce — no Save button to remember. Lives on the same `nutrition_day_notes` row that the legacy page wrote to, so existing data shows up automatically.
+
+### Changed
+- **`/nutrition/week` is now Week-only.** The legacy 937-line component had a "Today" subtab that was acting as a back-door to hydration / day-notes editing. With those features now native to `/nutrition/today`, the subtab + all its state (deviation editing, planned-meal logging, protein-target localStorage, dayBundle query) is deleted. The file is 398 lines and only does the Week template editor.
+
 ## [0.2.1] - 2026-05-01
 
 ### Added

--- a/TODOS.md
+++ b/TODOS.md
@@ -111,10 +111,12 @@
       each — proper prompt engineering + image upload pipeline + structured
       output validation + error UX. Deferred from this batch.
 
-- [ ] **Absorb hydration + day-notes editing into the new
-      `/nutrition/today` page.** The legacy `/nutrition/week` component
-      keeps the legacy "Today" subtab alive as a back-door to hydration logging
-      + free-text day notes. Once those features land properly on the new
-      Today page, the Today subtab inside the Week page can be deleted and
-      that file shrinks from ~937 lines to just the Week template editor.
+- [x] **Absorb hydration + day-notes editing into the new
+      `/nutrition/today` page.** New `DayNoteSection` component on Today
+      shows hydration in ml with +250/+500/+750 quick-add buttons, plus a
+      day-notes textarea. Both auto-save (600ms debounce) via the existing
+      `setDayNote` local-first mutation. The legacy `/nutrition/week` page
+      shrinks from 937 lines to 398 — the Today subtab and all its state
+      have been deleted; the file is now just the Week template editor.
+      **Completed:** v0.2.2 (2026-05-01)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebirth",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/src/app/nutrition/today/DayNoteSection.tsx
+++ b/src/app/nutrition/today/DayNoteSection.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Droplet, Pencil } from 'lucide-react';
+import { setDayNote } from '@/lib/mutations-nutrition';
+import { safeParseNumber } from '@/lib/nutrition-time';
+import type { LocalNutritionDayNote } from '@/db/local';
+
+interface Props {
+  date: string;
+  dayNote: LocalNutritionDayNote | undefined;
+}
+
+const QUICK_ADDS_ML = [250, 500, 750];
+
+/**
+ * Inline section for hydration logging and free-text day notes. Replaces the
+ * back-door subtab inside the legacy `/nutrition/week` page. Both fields
+ * persist via `setDayNote` (local-first → sync engine).
+ *
+ * Hydration takes quick-add buttons for the common pour sizes and an exact
+ * ml input for explicit overrides. Notes is a small textarea that grows.
+ * Both auto-save with a debounce so there's no Save button to remember.
+ */
+export function DayNoteSection({ date, dayNote }: Props) {
+  const [hydration, setHydration] = useState<string>('');
+  const [notes, setNotes] = useState<string>('');
+  const [saving, setSaving] = useState(false);
+
+  // Debounce auto-save so typing in notes doesn't fire on every keystroke.
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hydrate from server/Dexie state when the date or row changes.
+  useEffect(() => {
+    setHydration(dayNote?.hydration_ml != null ? String(dayNote.hydration_ml) : '');
+    setNotes(dayNote?.notes ?? '');
+  }, [date, dayNote?.hydration_ml, dayNote?.notes]);
+
+  function scheduleSave(nextHydrationStr: string, nextNotes: string) {
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(async () => {
+      setSaving(true);
+      try {
+        await setDayNote({
+          date,
+          hydration_ml: safeParseNumber(nextHydrationStr),
+          notes: nextNotes.trim() || null,
+        });
+      } finally {
+        setSaving(false);
+      }
+    }, 600);
+  }
+
+  function updateHydration(next: string) {
+    setHydration(next);
+    scheduleSave(next, notes);
+  }
+
+  function updateNotes(next: string) {
+    setNotes(next);
+    scheduleSave(hydration, next);
+  }
+
+  function addMl(delta: number) {
+    const current = safeParseNumber(hydration) ?? 0;
+    const next = String(Math.max(0, current + delta));
+    updateHydration(next);
+  }
+
+  return (
+    <section className="mt-6 ios-section overflow-hidden">
+      <div className="ios-row gap-3">
+        <Droplet className="size-4 text-sky-400" />
+        <div className="flex-1 flex items-center gap-2">
+          <input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            step={50}
+            value={hydration}
+            onChange={(e) => updateHydration(e.target.value)}
+            placeholder="0"
+            className="w-20 bg-transparent text-sm font-medium text-right outline-none tabular-nums"
+            aria-label="Hydration in millilitres"
+          />
+          <span className="text-xs text-muted-foreground">ml water</span>
+        </div>
+        <div className="flex gap-1">
+          {QUICK_ADDS_ML.map((ml) => (
+            <button
+              key={ml}
+              type="button"
+              onClick={() => addMl(ml)}
+              className="h-7 px-2 rounded-full bg-sky-500/10 text-sky-500 text-[11px] font-semibold hover:bg-sky-500/20 transition-colors"
+              aria-label={`Add ${ml} millilitres`}
+            >
+              +{ml}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="ios-row items-start gap-3 pt-2">
+        <Pencil className="size-4 text-muted-foreground mt-2" />
+        <textarea
+          value={notes}
+          onChange={(e) => updateNotes(e.target.value)}
+          rows={2}
+          placeholder="Notes for the day (felt, slept, training, …)"
+          className="flex-1 bg-transparent text-sm outline-none resize-none placeholder:text-muted-foreground"
+        />
+      </div>
+
+      {saving && (
+        <div className="px-4 pb-2 text-[10px] text-muted-foreground text-right">
+          Saving…
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/nutrition/today/page.tsx
+++ b/src/app/nutrition/today/page.tsx
@@ -21,6 +21,7 @@ import { EditFoodSheet } from './EditFoodSheet';
 import { ApproveDayButton } from './ApproveDayButton';
 import { SmartRepeatSuggestion } from './SmartRepeatSuggestion';
 import { EntryDock } from './EntryDock';
+import { DayNoteSection } from './DayNoteSection';
 import { GoalsSheet } from '../goals/GoalsSheet';
 
 const SLOTS: MealSlot[] = ['breakfast', 'lunch', 'dinner', 'snack'];
@@ -198,6 +199,8 @@ function NutritionTodayContent() {
           </div>
         );
       })}
+
+      <DayNoteSection date={date} dayNote={dayNote} />
 
       <div className="mt-6">
         <ApproveDayButton date={date} status={status} />

--- a/src/app/nutrition/week/page.tsx
+++ b/src/app/nutrition/week/page.tsx
@@ -1,931 +1,398 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ChevronLeft, ChevronRight, Plus, Trash2, Check, Pencil, X } from 'lucide-react';
+import { ChevronLeft, Pencil, Plus, Trash2 } from 'lucide-react';
 import Link from 'next/link';
-import type { NutritionLog, NutritionWeekMeal } from '@/types';
 import { rebirthJsonHeaders } from '@/lib/api/headers';
-import { FEED_QUERY_DEFAULTS } from '@/lib/api/feed';
 import { queryKeys } from '@/lib/api/query-keys';
 import { apiBase } from '@/lib/api/client';
-import {
-  dateToDayOfWeek,
-  fetchNutritionDayBundle,
-  fetchNutritionWeekAll,
-  type NutritionDayBundle,
-} from '@/lib/api/nutrition';
-
-// ── helpers ────────────────────────────────────────────────────────────────
-
-function toDateStr(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
-
-function offsetDate(base: string, days: number): string {
-  const d = new Date(base + 'T12:00:00');
-  d.setDate(d.getDate() + days);
-  return toDateStr(d);
-}
-
-function formatDateLabel(dateStr: string): string {
-  const today = toDateStr(new Date());
-  const yesterday = offsetDate(today, -1);
-  if (dateStr === today) return 'Today';
-  if (dateStr === yesterday) return 'Yesterday';
-  return new Date(dateStr + 'T12:00:00').toLocaleDateString('en-GB', {
-    weekday: 'short', day: 'numeric', month: 'short',
-  });
-}
+import { dateToDayOfWeek, fetchNutritionWeekAll } from '@/lib/api/nutrition';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
-// ── types ──────────────────────────────────────────────────────────────────
-
-interface AddMealForm {
+interface WeekMealForm {
   meal_name: string;
+  meal_slot: string;
   protein_g: string;
   calories: string;
-  notes: string;
+  quality_rating: string;
 }
 
-const EMPTY_FORM: AddMealForm = { meal_name: '', protein_g: '', calories: '', notes: '' };
+const EMPTY_FORM: WeekMealForm = {
+  meal_name: '',
+  meal_slot: '',
+  protein_g: '',
+  calories: '',
+  quality_rating: '',
+};
 
-// ── component ──────────────────────────────────────────────────────────────
-
+/**
+ * Standard Week template editor. Users build up a typical-week meal plan
+ * (one row per slot per day) that the Today page can later use as a
+ * planned-meal source. Daily macro logging happens at /nutrition/today.
+ *
+ * Lives at /nutrition/week (sub-nav: Week). The legacy combined Today+Week
+ * page used to live at /nutrition before being split into /nutrition/today
+ * and this file.
+ */
 export default function NutritionWeekPage() {
   const queryClient = useQueryClient();
-  const feedQueryKey = queryKeys.feed(FEED_QUERY_DEFAULTS.days, FEED_QUERY_DEFAULTS.timelineLimit);
 
-  // The Week-template editor. The legacy "Today" tab exists below the toggle
-  // for now as a back-door to hydration + day-notes editing until the new
-  // /nutrition/today page absorbs those features (TODOS.md). Users land on
-  // 'week' and can still flip to 'today' here if they need that surface.
-  const [activeTab, setActiveTab] = useState<'today' | 'week'>('week');
+  const [weekDay, setWeekDay] = useState(() => dateToDayOfWeek(new Date().toISOString().slice(0, 10)));
 
-  // ── Today tab state ──────────────────────────────────────────────────────
-  const [viewDate, setViewDate] = useState(() => toDateStr(new Date()));
-
-  // Add-meal form (unplanned)
   const [showAddForm, setShowAddForm] = useState(false);
-  const [addForm, setAddForm] = useState<AddMealForm>(EMPTY_FORM);
-  const [addingSave, setAddingSave] = useState(false);
+  const [addForm, setAddForm] = useState<WeekMealForm>(EMPTY_FORM);
+  const [editingUuid, setEditingUuid] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<WeekMealForm>(EMPTY_FORM);
 
-  // Deviation edit state: keyed by template meal uuid
-  const [editingTemplate, setEditingTemplate] = useState<string | null>(null);
-  const [deviationForm, setDeviationForm] = useState<AddMealForm>(EMPTY_FORM);
-
-  // End-of-day summary edits
-  const [hydrationInput, setHydrationInput] = useState('');
-  const [dayNoteInput, setDayNoteInput] = useState('');
-  const [savingNote, setSavingNote] = useState(false);
-
-  // Protein target from localStorage
-  const [proteinTarget, setProteinTarget] = useState(180);
-
-  // ── Standard Week tab state ───────────────────────────────────────────────
-  const [weekDay, setWeekDay] = useState(() => dateToDayOfWeek(toDateStr(new Date())));
-
-  // Add template meal form
-  const [showWeekAddForm, setShowWeekAddForm] = useState(false);
-  const [weekAddForm, setWeekAddForm] = useState({ meal_name: '', protein_g: '', calories: '', quality_rating: '', meal_slot: '' });
-  const [weekAddSaving, setWeekAddSaving] = useState(false);
-
-  // Edit template meal
-  const [editingWeekMeal, setEditingWeekMeal] = useState<string | null>(null);
-  const [weekEditForm, setWeekEditForm] = useState({ meal_name: '', protein_g: '', calories: '', quality_rating: '', meal_slot: '' });
-
-  // ── load protein target ───────────────────────────────────────────────────
-  useEffect(() => {
-    const saved = localStorage.getItem('rebirth-nutrition-protein-target');
-    if (saved) setProteinTarget(parseInt(saved, 10));
-  }, []);
-
-  const { data: dayBundle, isPending: loadingDay } = useQuery({
-    queryKey: queryKeys.nutrition.dayBundle(viewDate),
-    queryFn: () => fetchNutritionDayBundle(viewDate),
-    staleTime: 20_000,
-    placeholderData: (previousData) => previousData,
-  });
-
-  const templateMeals = dayBundle?.templateMeals ?? [];
-  const loggedMeals = dayBundle?.loggedMeals ?? [];
-
-  useEffect(() => {
-    const noteData = dayBundle?.dayNote;
-    setHydrationInput(noteData?.hydration_ml != null ? String(noteData.hydration_ml) : '');
-    setDayNoteInput(noteData?.notes ?? '');
-  }, [dayBundle?.dayNote, viewDate]);
-
-  const { data: allWeekMeals = [], isPending: loadingWeek } = useQuery({
+  const { data: allWeekMeals = [], isPending: loading } = useQuery({
     queryKey: queryKeys.nutrition.weekAll(),
     queryFn: fetchNutritionWeekAll,
-    staleTime: 60_000,
-    placeholderData: (previousData) => previousData,
+    staleTime: 20_000,
   });
 
-  const removeLogMut = useMutation({
-    mutationFn: (uuid: string) =>
-      fetch(`${apiBase()}/api/nutrition/${uuid}`, { method: 'DELETE', headers: rebirthJsonHeaders() }),
-    onMutate: async (uuid) => {
-      const key = queryKeys.nutrition.dayBundle(viewDate);
-      await queryClient.cancelQueries({ queryKey: key });
-      const prev = queryClient.getQueryData<NutritionDayBundle>(key);
-      queryClient.setQueryData<NutritionDayBundle | undefined>(key, (old) =>
-        old ? { ...old, loggedMeals: old.loggedMeals.filter((l) => l.uuid !== uuid) } : old
-      );
-      return { prev };
-    },
-    onError: (_err, _uuid, ctx) => {
-      if (ctx?.prev) {
-        queryClient.setQueryData(queryKeys.nutrition.dayBundle(viewDate), ctx.prev);
-      }
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.dayBundle(viewDate) });
-      queryClient.invalidateQueries({ queryKey: feedQueryKey });
-    },
-  });
+  const dayMeals = allWeekMeals.filter((m) => m.day_of_week === weekDay);
 
-  // ── derived ───────────────────────────────────────────────────────────────
-  const dayMeals = allWeekMeals.filter(m => m.day_of_week === weekDay);
-
-  // Map template_meal_id → logged meal for quick lookup
-  const logsByTemplate = new Map<string, NutritionLog>();
-  for (const l of loggedMeals) {
-    if (l.template_meal_id) logsByTemplate.set(l.template_meal_id, l);
-  }
-  const unplannedLogs = loggedMeals.filter(l => l.status === 'added');
-
-  const totalProtein = loggedMeals.reduce((s, l) => s + (l.protein_g ?? 0), 0);
-  const totalCalories = loggedMeals.reduce((s, l) => s + (l.calories ?? 0), 0);
-
-  // ── handlers: Today tab ───────────────────────────────────────────────────
-
-  async function logAsPlanned(meal: NutritionWeekMeal) {
-    const today = toDateStr(new Date());
-    const loggedAt = viewDate === today
-      ? new Date().toISOString()
-      : viewDate + 'T12:00:00.000Z';
-    const res = await fetch(`${apiBase()}/api/nutrition`, {
-      method: 'POST',
-      headers: rebirthJsonHeaders(),
-      body: JSON.stringify({
-        logged_at: loggedAt,
-        meal_name: meal.meal_name,
-        template_meal_id: meal.uuid,
-        protein_g: meal.protein_g,
-        calories: meal.calories,
-        status: 'planned',
-      }),
-    });
-    if (res.ok) {
-      await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.dayBundle(viewDate) });
-      queryClient.invalidateQueries({ queryKey: feedQueryKey });
-    }
+  function invalidate() {
+    return queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.weekAll() });
   }
 
-  async function logDeviation(meal: NutritionWeekMeal) {
-    if (!deviationForm.meal_name && !deviationForm.protein_g && !deviationForm.calories) return;
-    const today = toDateStr(new Date());
-    const loggedAt = viewDate === today
-      ? new Date().toISOString()
-      : viewDate + 'T12:00:00.000Z';
-    const res = await fetch(`${apiBase()}/api/nutrition`, {
-      method: 'POST',
-      headers: rebirthJsonHeaders(),
-      body: JSON.stringify({
-        logged_at: loggedAt,
-        meal_name: deviationForm.meal_name || meal.meal_name,
-        template_meal_id: meal.uuid,
-        protein_g: deviationForm.protein_g ? parseFloat(deviationForm.protein_g) : null,
-        calories: deviationForm.calories ? parseFloat(deviationForm.calories) : null,
-        notes: deviationForm.notes || null,
-        status: 'deviation',
-      }),
-    });
-    if (res.ok) {
-      setEditingTemplate(null);
-      setDeviationForm(EMPTY_FORM);
-      await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.dayBundle(viewDate) });
-      queryClient.invalidateQueries({ queryKey: feedQueryKey });
-    }
-  }
-
-  function removeLog(uuid: string) {
-    removeLogMut.mutate(uuid);
-  }
-
-  async function saveAddForm() {
-    if (!addForm.meal_name) return;
-    setAddingSave(true);
-    const today = toDateStr(new Date());
-    const loggedAt = viewDate === today
-      ? new Date().toISOString()
-      : viewDate + 'T12:00:00.000Z';
-    try {
-      const res = await fetch(`${apiBase()}/api/nutrition`, {
-        method: 'POST',
-        headers: rebirthJsonHeaders(),
-        body: JSON.stringify({
-          logged_at: loggedAt,
-          meal_name: addForm.meal_name,
-          protein_g: addForm.protein_g ? parseFloat(addForm.protein_g) : null,
-          calories: addForm.calories ? parseFloat(addForm.calories) : null,
-          notes: addForm.notes || null,
-          status: 'added',
-        }),
-      });
-      if (res.ok) {
-        setAddForm(EMPTY_FORM);
-        setShowAddForm(false);
-        await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.dayBundle(viewDate) });
-        queryClient.invalidateQueries({ queryKey: feedQueryKey });
-      }
-    } finally {
-      setAddingSave(false);
-    }
-  }
-
-  async function saveDayNote() {
-    setSavingNote(true);
-    try {
-      const res = await fetch(`${apiBase()}/api/nutrition/day-notes`, {
-        method: 'POST',
-        headers: rebirthJsonHeaders(),
-        body: JSON.stringify({
-          date: viewDate,
-          hydration_ml: hydrationInput ? parseInt(hydrationInput, 10) : null,
-          notes: dayNoteInput || null,
-        }),
-      });
-      if (res.ok) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.dayBundle(viewDate) });
-      }
-    } finally {
-      setSavingNote(false);
-    }
-  }
-
-  // ── handlers: Standard Week tab ───────────────────────────────────────────
-
-  async function saveWeekMeal() {
-    if (!weekAddForm.meal_name) return;
-    setWeekAddSaving(true);
-    try {
+  const addMutation = useMutation({
+    mutationFn: async (form: WeekMealForm) => {
       const res = await fetch(`${apiBase()}/api/nutrition/week`, {
         method: 'POST',
         headers: rebirthJsonHeaders(),
         body: JSON.stringify({
           day_of_week: weekDay,
-          meal_slot: weekAddForm.meal_slot || '',
-          meal_name: weekAddForm.meal_name,
-          protein_g: weekAddForm.protein_g ? parseFloat(weekAddForm.protein_g) : null,
-          calories: weekAddForm.calories ? parseFloat(weekAddForm.calories) : null,
-          quality_rating: weekAddForm.quality_rating ? parseInt(weekAddForm.quality_rating, 10) : null,
+          meal_slot: form.meal_slot || '',
+          meal_name: form.meal_name,
+          protein_g: form.protein_g ? parseFloat(form.protein_g) : null,
+          calories: form.calories ? parseFloat(form.calories) : null,
+          quality_rating: form.quality_rating ? parseInt(form.quality_rating, 10) : null,
           sort_order: dayMeals.length,
         }),
       });
-      if (res.ok) {
-        setWeekAddForm({ meal_name: '', protein_g: '', calories: '', quality_rating: '', meal_slot: '' });
-        setShowWeekAddForm(false);
-        await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.weekAll() });
-        await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.dayBundle(viewDate) });
-      }
-    } finally {
-      setWeekAddSaving(false);
-    }
-  }
+      if (!res.ok) throw new Error(`POST /api/nutrition/week failed (${res.status})`);
+    },
+    onSuccess: async () => {
+      setAddForm(EMPTY_FORM);
+      setShowAddForm(false);
+      await invalidate();
+    },
+  });
 
-  async function saveWeekEdit(uuid: string) {
-    const res = await fetch(`${apiBase()}/api/nutrition/week/${uuid}`, {
-      method: 'PATCH',
-      headers: rebirthJsonHeaders(),
-      body: JSON.stringify({
-        meal_name: weekEditForm.meal_name,
-        meal_slot: weekEditForm.meal_slot,
-        protein_g: weekEditForm.protein_g ? parseFloat(weekEditForm.protein_g) : null,
-        calories: weekEditForm.calories ? parseFloat(weekEditForm.calories) : null,
-        quality_rating: weekEditForm.quality_rating ? parseInt(weekEditForm.quality_rating, 10) : null,
-      }),
-    });
-    if (res.ok) {
-      setEditingWeekMeal(null);
-      await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.weekAll() });
-      await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.dayBundle(viewDate) });
-    }
-  }
+  const editMutation = useMutation({
+    mutationFn: async ({ uuid, form }: { uuid: string; form: WeekMealForm }) => {
+      const res = await fetch(`${apiBase()}/api/nutrition/week/${uuid}`, {
+        method: 'PATCH',
+        headers: rebirthJsonHeaders(),
+        body: JSON.stringify({
+          meal_name: form.meal_name,
+          meal_slot: form.meal_slot,
+          protein_g: form.protein_g ? parseFloat(form.protein_g) : null,
+          calories: form.calories ? parseFloat(form.calories) : null,
+          quality_rating: form.quality_rating ? parseInt(form.quality_rating, 10) : null,
+        }),
+      });
+      if (!res.ok) throw new Error(`PATCH /api/nutrition/week/{uuid} failed (${res.status})`);
+    },
+    onSuccess: async () => {
+      setEditingUuid(null);
+      await invalidate();
+    },
+  });
 
-  async function deleteWeekMeal(uuid: string) {
-    await fetch(`${apiBase()}/api/nutrition/week/${uuid}`, { method: 'DELETE', headers: rebirthJsonHeaders() });
-    await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.weekAll() });
-    await queryClient.invalidateQueries({ queryKey: queryKeys.nutrition.dayBundle(viewDate) });
-  }
-
-  // ── render ─────────────────────────────────────────────────────────────────
+  const deleteMutation = useMutation({
+    mutationFn: async (uuid: string) => {
+      await fetch(`${apiBase()}/api/nutrition/week/${uuid}`, {
+        method: 'DELETE',
+        headers: rebirthJsonHeaders(),
+      });
+    },
+    onSuccess: () => invalidate(),
+  });
 
   return (
     <main className="tab-content bg-background">
-      {/* Header */}
-      <div className="px-4 pt-safe pb-3 flex items-center gap-3">
+      <header className="px-4 pt-safe pb-3 flex items-center gap-3">
         <Link href="/settings" className="text-primary p-1 -ml-1">
           <ChevronLeft className="h-5 w-5" />
         </Link>
         <h1 className="text-2xl font-bold">Standard Week</h1>
-        <button
-          type="button"
-          onClick={() => setActiveTab(activeTab === 'today' ? 'week' : 'today')}
-          className="ml-auto text-xs text-muted-foreground hover:text-foreground"
-        >
-          {activeTab === 'today' ? 'Show week template' : 'Hydration / notes'}
-        </button>
-      </div>
+      </header>
 
-      {/* ── TODAY TAB ─────────────────────────────────────────────────────── */}
-      {activeTab === 'today' && (
-        <div className="px-4 space-y-4 pb-8">
-          {/* Date navigation */}
-          <div className="flex items-center justify-between">
-            <button
-              onClick={() => setViewDate(d => offsetDate(d, -1))}
-              className="p-2 text-primary min-h-[44px] min-w-[44px] flex items-center justify-center"
-            >
-              <ChevronLeft className="h-5 w-5" />
-            </button>
-            <span className="text-base font-semibold">{formatDateLabel(viewDate)}</span>
-            <button
-              onClick={() => setViewDate(d => offsetDate(d, 1))}
-              className="p-2 text-primary min-h-[44px] min-w-[44px] flex items-center justify-center"
-            >
-              <ChevronRight className="h-5 w-5" />
-            </button>
+      <div className="pb-8">
+        {/* Day selector */}
+        <div className="px-4 mb-4">
+          <div className="flex gap-1">
+            {DAY_LABELS.map((label, i) => (
+              <button
+                key={label}
+                type="button"
+                onClick={() => setWeekDay(i)}
+                className={`flex-1 py-2 text-xs font-medium rounded-lg transition-colors ${
+                  weekDay === i ? 'bg-primary text-white' : 'bg-secondary text-foreground'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
           </div>
+        </div>
 
-          {loadingDay ? (
-            <p className="text-xs text-muted-foreground px-1">Loading…</p>
-          ) : (
-            <>
-              {/* Template meals */}
-              {templateMeals.length > 0 && (
-                <div>
-                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Planned meals</p>
-                  <div className="ios-section">
-                    {templateMeals.map((meal, i) => {
-                      const logged = logsByTemplate.get(meal.uuid);
-                      const isEditing = editingTemplate === meal.uuid;
-                      return (
-                        <div
-                          key={meal.uuid}
-                          className={`flex flex-col gap-1 py-3 px-4 ${i < templateMeals.length - 1 ? 'border-b border-border' : ''}`}
-                        >
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="flex-1 min-w-0">
-                              <span className={`text-sm font-medium ${logged ? 'text-muted-foreground line-through' : ''}`}>
-                                {meal.meal_name}
-                              </span>
-                              <div className="flex gap-3 mt-0.5">
-                                {meal.protein_g != null && (
-                                  <span className="text-xs text-muted-foreground">{meal.protein_g}g protein</span>
-                                )}
-                                {meal.calories != null && (
-                                  <span className="text-xs text-muted-foreground">{meal.calories} kcal</span>
-                                )}
-                              </div>
-                            </div>
-                            {logged ? (
-                              <div className="flex items-center gap-2">
-                                {logged.status === 'deviation' && (
-                                  <span className="text-xs text-orange-500 font-medium">deviation</span>
-                                )}
-                                <span className="text-xs text-green-600 font-semibold">✓</span>
-                                <button
-                                  onClick={() => removeLog(logged.uuid)}
-                                  className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
-                                >
-                                  <X className="h-4 w-4" />
-                                </button>
-                              </div>
-                            ) : (
-                              <div className="flex items-center gap-1">
-                                <button
-                                  onClick={() => logAsPlanned(meal)}
-                                  className="p-2 text-green-600 min-h-[44px] min-w-[44px] flex items-center justify-center"
-                                  title="Log as planned"
-                                >
-                                  <Check className="h-5 w-5" />
-                                </button>
-                                <button
-                                  onClick={() => {
-                                    if (isEditing) {
-                                      setEditingTemplate(null);
-                                    } else {
-                                      setEditingTemplate(meal.uuid);
-                                      setDeviationForm({ meal_name: meal.meal_name, protein_g: String(meal.protein_g ?? ''), calories: String(meal.calories ?? ''), notes: '' });
-                                    }
-                                  }}
-                                  className="p-2 text-muted-foreground min-h-[44px] min-w-[44px] flex items-center justify-center"
-                                  title="Log deviation"
-                                >
-                                  <Pencil className="h-4 w-4" />
-                                </button>
-                              </div>
-                            )}
-                          </div>
+        <div className="px-4 space-y-4">
+          {loading && <p className="text-xs text-muted-foreground px-1">Loading…</p>}
 
-                          {/* Deviation form */}
-                          {isEditing && !logged && (
-                            <div className="mt-1 space-y-2 bg-secondary/40 rounded-lg p-3">
-                              <p className="text-xs font-medium text-muted-foreground">Log deviation</p>
-                              <input
-                                type="text"
-                                placeholder="Meal name"
-                                value={deviationForm.meal_name}
-                                onChange={e => setDeviationForm(f => ({ ...f, meal_name: e.target.value }))}
-                                className="w-full bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                              />
-                              <div className="flex gap-2">
-                                <input
-                                  type="number"
-                                  inputMode="decimal"
-                                  placeholder="Protein (g)"
-                                  value={deviationForm.protein_g}
-                                  onChange={e => setDeviationForm(f => ({ ...f, protein_g: e.target.value }))}
-                                  className="flex-1 bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                                />
-                                <input
-                                  type="number"
-                                  inputMode="decimal"
-                                  placeholder="Calories"
-                                  value={deviationForm.calories}
-                                  onChange={e => setDeviationForm(f => ({ ...f, calories: e.target.value }))}
-                                  className="flex-1 bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                                />
-                              </div>
-                              <input
-                                type="text"
-                                placeholder="Notes (optional)"
-                                value={deviationForm.notes}
-                                onChange={e => setDeviationForm(f => ({ ...f, notes: e.target.value }))}
-                                className="w-full bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                              />
-                              <div className="flex justify-end gap-2 pt-1">
-                                <button
-                                  onClick={() => setEditingTemplate(null)}
-                                  className="px-3 py-1.5 text-sm text-muted-foreground"
-                                >
-                                  Cancel
-                                </button>
-                                <button
-                                  onClick={() => logDeviation(meal)}
-                                  className="px-3 py-1.5 bg-primary text-white text-sm font-medium rounded-lg"
-                                >
-                                  Save
-                                </button>
-                              </div>
-                            </div>
-                          )}
-
-                          {/* Show logged deviation details */}
-                          {logged && logged.status === 'deviation' && (
-                            <div className="flex gap-3 mt-0.5 pl-0">
-                              {logged.meal_name && (
-                                <span className="text-xs text-foreground">{logged.meal_name}</span>
-                              )}
-                              {logged.protein_g != null && (
-                                <span className="text-xs text-muted-foreground">{logged.protein_g}g protein</span>
-                              )}
-                              {logged.calories != null && (
-                                <span className="text-xs text-muted-foreground">{logged.calories} kcal</span>
-                              )}
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-
-              {/* Unplanned logged meals */}
-              {unplannedLogs.length > 0 && (
-                <div>
-                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Added meals</p>
-                  <div className="ios-section">
-                    {unplannedLogs.map((log, i) => (
-                      <div
-                        key={log.uuid}
-                        className={`ios-row justify-between ${i < unplannedLogs.length - 1 ? 'border-b border-border' : ''}`}
-                      >
-                        <div className="flex-1 min-w-0">
-                          <span className="text-sm font-medium">{log.meal_name ?? 'Meal'}</span>
-                          <div className="flex gap-3 mt-0.5">
-                            {log.protein_g != null && (
-                              <span className="text-xs text-muted-foreground">{log.protein_g}g protein</span>
-                            )}
-                            {log.calories != null && (
-                              <span className="text-xs text-muted-foreground">{log.calories} kcal</span>
-                            )}
-                          </div>
-                        </div>
-                        <button
-                          onClick={() => removeLog(log.uuid)}
-                          className="text-red-500 p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Empty state */}
-              {templateMeals.length === 0 && loggedMeals.length === 0 && (
-                <p className="text-xs text-muted-foreground px-1">
-                  No meals planned for this day.{' '}
-                  <button
-                    onClick={() => setActiveTab('week')}
-                    className="text-primary underline"
+          {!loading && dayMeals.length > 0 && (
+            <div className="ios-section">
+              {dayMeals.map((meal, i) => {
+                const isEditing = editingUuid === meal.uuid;
+                return (
+                  <div
+                    key={meal.uuid}
+                    className={`flex flex-col gap-1 py-3 px-4 ${i < dayMeals.length - 1 ? 'border-b border-border' : ''}`}
                   >
-                    Set up Standard Week
-                  </button>
-                </p>
-              )}
+                    {!isEditing ? (
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex-1 min-w-0">
+                          <span className="text-sm font-medium">{meal.meal_name}</span>
+                          {meal.meal_slot && (
+                            <span className="ml-2 text-xs text-muted-foreground">{meal.meal_slot}</span>
+                          )}
+                          <div className="flex gap-3 mt-0.5">
+                            {meal.protein_g != null && (
+                              <span className="text-xs text-muted-foreground">{meal.protein_g}g protein</span>
+                            )}
+                            {meal.calories != null && (
+                              <span className="text-xs text-muted-foreground">{meal.calories} kcal</span>
+                            )}
+                            {meal.quality_rating != null && (
+                              <span className="text-xs text-muted-foreground">★ {meal.quality_rating}/5</span>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-0">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingUuid(meal.uuid);
+                              setEditForm({
+                                meal_name: meal.meal_name,
+                                meal_slot: meal.meal_slot,
+                                protein_g: String(meal.protein_g ?? ''),
+                                calories: String(meal.calories ?? ''),
+                                quality_rating: String(meal.quality_rating ?? ''),
+                              });
+                            }}
+                            className="p-2 text-muted-foreground min-h-[44px] min-w-[44px] flex items-center justify-center"
+                            aria-label="Edit meal"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => deleteMutation.mutate(meal.uuid)}
+                            className="p-2 text-red-500 min-h-[44px] min-w-[44px] flex items-center justify-center"
+                            aria-label="Delete meal"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <MealEditFields
+                        form={editForm}
+                        onChange={setEditForm}
+                        onSave={() => editMutation.mutate({ uuid: meal.uuid, form: editForm })}
+                        onCancel={() => setEditingUuid(null)}
+                        saving={editMutation.isPending}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
 
-              {/* Add unplanned meal */}
-              {!showAddForm ? (
-                <button
-                  onClick={() => setShowAddForm(true)}
-                  className="flex items-center gap-2 text-primary text-sm font-medium px-1 min-h-[44px]"
-                >
-                  <Plus className="h-4 w-4" />
-                  Add meal
-                </button>
-              ) : (
-                <div>
-                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Add meal</p>
-                  <div className="ios-section">
-                    <div className="ios-row">
-                      <input
-                        type="text"
-                        placeholder="Meal name"
-                        value={addForm.meal_name}
-                        onChange={e => setAddForm(f => ({ ...f, meal_name: e.target.value }))}
-                        className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
-                      />
-                    </div>
-                    <div className="ios-row gap-3">
-                      <input
-                        type="number"
-                        inputMode="decimal"
-                        placeholder="Protein (g)"
-                        value={addForm.protein_g}
-                        onChange={e => setAddForm(f => ({ ...f, protein_g: e.target.value }))}
-                        className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
-                      />
-                      <input
-                        type="number"
-                        inputMode="decimal"
-                        placeholder="Calories"
-                        value={addForm.calories}
-                        onChange={e => setAddForm(f => ({ ...f, calories: e.target.value }))}
-                        className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
-                      />
-                    </div>
-                    <div className="ios-row">
-                      <input
-                        type="text"
-                        placeholder="Notes (optional)"
-                        value={addForm.notes}
-                        onChange={e => setAddForm(f => ({ ...f, notes: e.target.value }))}
-                        className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
-                      />
-                    </div>
-                    <div className="ios-row justify-end gap-2">
-                      <button
-                        onClick={() => { setShowAddForm(false); setAddForm(EMPTY_FORM); }}
-                        className="px-3 py-1.5 text-sm text-muted-foreground"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        onClick={saveAddForm}
-                        disabled={addingSave || !addForm.meal_name}
-                        className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
-                      >
-                        {addingSave ? 'Saving…' : 'Add'}
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              )}
+          {!loading && dayMeals.length === 0 && !showAddForm && (
+            <p className="text-xs text-muted-foreground px-1">No meals defined for {DAY_LABELS[weekDay]}.</p>
+          )}
 
-              {/* End-of-day summary */}
-              <div>
-                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">Daily summary</p>
-                <div className="ios-section">
-                  {/* Protein progress */}
-                  <div className="ios-row justify-between">
-                    <span className="text-sm font-medium">Protein</span>
-                    <span className={`text-sm font-semibold ${totalProtein >= proteinTarget ? 'text-green-600' : 'text-foreground'}`}>
-                      {Math.round(totalProtein)}
-                      <span className="text-xs font-normal text-muted-foreground"> / {proteinTarget}g</span>
-                    </span>
-                  </div>
-                  {/* Calories */}
-                  {totalCalories > 0 && (
-                    <div className="ios-row justify-between">
-                      <span className="text-sm font-medium">Calories</span>
-                      <span className="text-sm text-muted-foreground">{Math.round(totalCalories)} kcal</span>
-                    </div>
-                  )}
-                  {/* Protein target edit */}
-                  <div className="ios-row justify-between">
-                    <span className="text-sm text-muted-foreground">Protein target</span>
-                    <input
-                      type="number"
-                      inputMode="numeric"
-                      value={proteinTarget}
-                      onChange={e => {
-                        const v = parseInt(e.target.value, 10);
-                        if (v > 0) {
-                          setProteinTarget(v);
-                          localStorage.setItem('rebirth-nutrition-protein-target', String(v));
-                        }
-                      }}
-                      className="w-16 bg-transparent text-sm text-right outline-none text-muted-foreground"
-                    />
-                  </div>
-                  {/* Hydration */}
-                  <div className="ios-row justify-between gap-3">
-                    <span className="text-sm font-medium">Hydration (ml)</span>
-                    <input
-                      type="number"
-                      inputMode="numeric"
-                      placeholder="0"
-                      value={hydrationInput}
-                      onChange={e => setHydrationInput(e.target.value)}
-                      className="w-20 bg-transparent text-sm text-right outline-none"
-                    />
-                  </div>
-                  {/* Notes */}
-                  <div className="ios-row">
-                    <input
-                      type="text"
-                      placeholder="Day notes (optional)"
-                      value={dayNoteInput}
-                      onChange={e => setDayNoteInput(e.target.value)}
-                      className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
-                    />
-                  </div>
-                  <div className="ios-row justify-end">
-                    <button
-                      onClick={saveDayNote}
-                      disabled={savingNote}
-                      className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
-                    >
-                      {savingNote ? 'Saving…' : 'Save'}
-                    </button>
-                  </div>
-                </div>
+          {!showAddForm ? (
+            <button
+              type="button"
+              onClick={() => setShowAddForm(true)}
+              className="flex items-center gap-2 text-primary text-sm font-medium px-1 min-h-[44px]"
+            >
+              <Plus className="h-4 w-4" />
+              Add meal for {DAY_LABELS[weekDay]}
+            </button>
+          ) : (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">
+                New meal — {DAY_LABELS[weekDay]}
+              </p>
+              <div className="ios-section">
+                <MealAddFields
+                  form={addForm}
+                  onChange={setAddForm}
+                  onCancel={() => {
+                    setShowAddForm(false);
+                    setAddForm(EMPTY_FORM);
+                  }}
+                  onSave={() => addMutation.mutate(addForm)}
+                  saving={addMutation.isPending}
+                />
               </div>
-            </>
+            </div>
           )}
         </div>
-      )}
-
-      {/* ── STANDARD WEEK TAB ─────────────────────────────────────────────── */}
-      {activeTab === 'week' && (
-        <div className="pb-8">
-          {/* Day selector */}
-          <div className="px-4 mb-4">
-            <div className="flex gap-1">
-              {DAY_LABELS.map((label, i) => (
-                <button
-                  key={i}
-                  onClick={() => setWeekDay(i)}
-                  className={`flex-1 py-2 text-xs font-medium rounded-lg transition-colors ${
-                    weekDay === i ? 'bg-primary text-white' : 'bg-secondary text-foreground'
-                  }`}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="px-4 space-y-4">
-            {loadingWeek ? (
-              <p className="text-xs text-muted-foreground px-1">Loading…</p>
-            ) : (
-              <>
-                {/* Meal list for selected day */}
-                {dayMeals.length > 0 && (
-                  <div className="ios-section">
-                    {dayMeals.map((meal, i) => {
-                      const isEditing = editingWeekMeal === meal.uuid;
-                      return (
-                        <div
-                          key={meal.uuid}
-                          className={`flex flex-col gap-1 py-3 px-4 ${i < dayMeals.length - 1 ? 'border-b border-border' : ''}`}
-                        >
-                          {!isEditing ? (
-                            <div className="flex items-center justify-between gap-2">
-                              <div className="flex-1 min-w-0">
-                                <span className="text-sm font-medium">{meal.meal_name}</span>
-                                {meal.meal_slot && (
-                                  <span className="ml-2 text-xs text-muted-foreground">{meal.meal_slot}</span>
-                                )}
-                                <div className="flex gap-3 mt-0.5">
-                                  {meal.protein_g != null && (
-                                    <span className="text-xs text-muted-foreground">{meal.protein_g}g protein</span>
-                                  )}
-                                  {meal.calories != null && (
-                                    <span className="text-xs text-muted-foreground">{meal.calories} kcal</span>
-                                  )}
-                                  {meal.quality_rating != null && (
-                                    <span className="text-xs text-muted-foreground">★ {meal.quality_rating}/5</span>
-                                  )}
-                                </div>
-                              </div>
-                              <div className="flex items-center gap-0">
-                                <button
-                                  onClick={() => {
-                                    setEditingWeekMeal(meal.uuid);
-                                    setWeekEditForm({
-                                      meal_name: meal.meal_name,
-                                      meal_slot: meal.meal_slot,
-                                      protein_g: String(meal.protein_g ?? ''),
-                                      calories: String(meal.calories ?? ''),
-                                      quality_rating: String(meal.quality_rating ?? ''),
-                                    });
-                                  }}
-                                  className="p-2 text-muted-foreground min-h-[44px] min-w-[44px] flex items-center justify-center"
-                                >
-                                  <Pencil className="h-4 w-4" />
-                                </button>
-                                <button
-                                  onClick={() => deleteWeekMeal(meal.uuid)}
-                                  className="p-2 text-red-500 min-h-[44px] min-w-[44px] flex items-center justify-center"
-                                >
-                                  <Trash2 className="h-4 w-4" />
-                                </button>
-                              </div>
-                            </div>
-                          ) : (
-                            <div className="space-y-2">
-                              <input
-                                type="text"
-                                placeholder="Meal name"
-                                value={weekEditForm.meal_name}
-                                onChange={e => setWeekEditForm(f => ({ ...f, meal_name: e.target.value }))}
-                                className="w-full bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                              />
-                              <input
-                                type="text"
-                                placeholder="Slot (e.g. breakfast)"
-                                value={weekEditForm.meal_slot}
-                                onChange={e => setWeekEditForm(f => ({ ...f, meal_slot: e.target.value }))}
-                                className="w-full bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                              />
-                              <div className="flex gap-2">
-                                <input
-                                  type="number"
-                                  inputMode="decimal"
-                                  placeholder="Protein (g)"
-                                  value={weekEditForm.protein_g}
-                                  onChange={e => setWeekEditForm(f => ({ ...f, protein_g: e.target.value }))}
-                                  className="flex-1 bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                                />
-                                <input
-                                  type="number"
-                                  inputMode="decimal"
-                                  placeholder="Calories"
-                                  value={weekEditForm.calories}
-                                  onChange={e => setWeekEditForm(f => ({ ...f, calories: e.target.value }))}
-                                  className="flex-1 bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                                />
-                                <input
-                                  type="number"
-                                  inputMode="numeric"
-                                  placeholder="Quality (1-5)"
-                                  value={weekEditForm.quality_rating}
-                                  min={1}
-                                  max={5}
-                                  onChange={e => setWeekEditForm(f => ({ ...f, quality_rating: e.target.value }))}
-                                  className="w-24 bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
-                                />
-                              </div>
-                              <div className="flex justify-end gap-2 pt-1">
-                                <button
-                                  onClick={() => setEditingWeekMeal(null)}
-                                  className="px-3 py-1.5 text-sm text-muted-foreground"
-                                >
-                                  Cancel
-                                </button>
-                                <button
-                                  onClick={() => saveWeekEdit(meal.uuid)}
-                                  className="px-3 py-1.5 bg-primary text-white text-sm font-medium rounded-lg"
-                                >
-                                  Save
-                                </button>
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-
-                {dayMeals.length === 0 && !showWeekAddForm && (
-                  <p className="text-xs text-muted-foreground px-1">No meals defined for {DAY_LABELS[weekDay]}.</p>
-                )}
-
-                {/* Add template meal form */}
-                {!showWeekAddForm ? (
-                  <button
-                    onClick={() => setShowWeekAddForm(true)}
-                    className="flex items-center gap-2 text-primary text-sm font-medium px-1 min-h-[44px]"
-                  >
-                    <Plus className="h-4 w-4" />
-                    Add meal for {DAY_LABELS[weekDay]}
-                  </button>
-                ) : (
-                  <div>
-                    <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1 px-1">
-                      New meal — {DAY_LABELS[weekDay]}
-                    </p>
-                    <div className="ios-section">
-                      <div className="ios-row">
-                        <input
-                          type="text"
-                          placeholder="Meal name"
-                          value={weekAddForm.meal_name}
-                          onChange={e => setWeekAddForm(f => ({ ...f, meal_name: e.target.value }))}
-                          className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
-                        />
-                      </div>
-                      <div className="ios-row">
-                        <input
-                          type="text"
-                          placeholder="Slot (e.g. breakfast, snack 1)"
-                          value={weekAddForm.meal_slot}
-                          onChange={e => setWeekAddForm(f => ({ ...f, meal_slot: e.target.value }))}
-                          className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
-                        />
-                      </div>
-                      <div className="ios-row gap-3 flex-wrap">
-                        <input
-                          type="number"
-                          inputMode="decimal"
-                          placeholder="Protein (g)"
-                          value={weekAddForm.protein_g}
-                          onChange={e => setWeekAddForm(f => ({ ...f, protein_g: e.target.value }))}
-                          className="flex-1 min-w-[80px] bg-transparent text-sm outline-none min-h-[44px]"
-                        />
-                        <input
-                          type="number"
-                          inputMode="decimal"
-                          placeholder="Calories"
-                          value={weekAddForm.calories}
-                          onChange={e => setWeekAddForm(f => ({ ...f, calories: e.target.value }))}
-                          className="flex-1 min-w-[80px] bg-transparent text-sm outline-none min-h-[44px]"
-                        />
-                        <input
-                          type="number"
-                          inputMode="numeric"
-                          placeholder="Quality (1-5)"
-                          value={weekAddForm.quality_rating}
-                          min={1}
-                          max={5}
-                          onChange={e => setWeekAddForm(f => ({ ...f, quality_rating: e.target.value }))}
-                          className="w-28 bg-transparent text-sm outline-none min-h-[44px]"
-                        />
-                      </div>
-                      <div className="ios-row justify-end gap-2">
-                        <button
-                          onClick={() => { setShowWeekAddForm(false); setWeekAddForm({ meal_name: '', protein_g: '', calories: '', quality_rating: '', meal_slot: '' }); }}
-                          className="px-3 py-1.5 text-sm text-muted-foreground"
-                        >
-                          Cancel
-                        </button>
-                        <button
-                          onClick={saveWeekMeal}
-                          disabled={weekAddSaving || !weekAddForm.meal_name}
-                          className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
-                        >
-                          {weekAddSaving ? 'Saving…' : 'Add'}
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-      )}
+      </div>
     </main>
+  );
+}
+
+interface FieldsProps {
+  form: WeekMealForm;
+  onChange: (f: WeekMealForm) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+}
+
+function MealEditFields({ form, onChange, onSave, onCancel, saving }: FieldsProps) {
+  return (
+    <div className="space-y-2">
+      <input
+        type="text"
+        placeholder="Meal name"
+        value={form.meal_name}
+        onChange={(e) => onChange({ ...form, meal_name: e.target.value })}
+        className="w-full bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
+      />
+      <input
+        type="text"
+        placeholder="Slot (e.g. breakfast)"
+        value={form.meal_slot}
+        onChange={(e) => onChange({ ...form, meal_slot: e.target.value })}
+        className="w-full bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
+      />
+      <div className="flex gap-2">
+        <input
+          type="number"
+          inputMode="decimal"
+          placeholder="Protein (g)"
+          value={form.protein_g}
+          onChange={(e) => onChange({ ...form, protein_g: e.target.value })}
+          className="flex-1 bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
+        />
+        <input
+          type="number"
+          inputMode="decimal"
+          placeholder="Calories"
+          value={form.calories}
+          onChange={(e) => onChange({ ...form, calories: e.target.value })}
+          className="flex-1 bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
+        />
+        <input
+          type="number"
+          inputMode="numeric"
+          placeholder="Quality (1-5)"
+          value={form.quality_rating}
+          min={1}
+          max={5}
+          onChange={(e) => onChange({ ...form, quality_rating: e.target.value })}
+          className="w-24 bg-transparent text-sm outline-none border-b border-border pb-1 min-h-[36px]"
+        />
+      </div>
+      <div className="flex justify-end gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm text-muted-foreground"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving}
+          className="px-3 py-1.5 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MealAddFields({ form, onChange, onSave, onCancel, saving }: FieldsProps) {
+  return (
+    <>
+      <div className="ios-row">
+        <input
+          type="text"
+          placeholder="Meal name"
+          value={form.meal_name}
+          onChange={(e) => onChange({ ...form, meal_name: e.target.value })}
+          className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
+        />
+      </div>
+      <div className="ios-row">
+        <input
+          type="text"
+          placeholder="Slot (e.g. breakfast, snack 1)"
+          value={form.meal_slot}
+          onChange={(e) => onChange({ ...form, meal_slot: e.target.value })}
+          className="flex-1 bg-transparent text-sm outline-none min-h-[44px]"
+        />
+      </div>
+      <div className="ios-row gap-3 flex-wrap">
+        <input
+          type="number"
+          inputMode="decimal"
+          placeholder="Protein (g)"
+          value={form.protein_g}
+          onChange={(e) => onChange({ ...form, protein_g: e.target.value })}
+          className="flex-1 min-w-[80px] bg-transparent text-sm outline-none min-h-[44px]"
+        />
+        <input
+          type="number"
+          inputMode="decimal"
+          placeholder="Calories"
+          value={form.calories}
+          onChange={(e) => onChange({ ...form, calories: e.target.value })}
+          className="flex-1 min-w-[80px] bg-transparent text-sm outline-none min-h-[44px]"
+        />
+        <input
+          type="number"
+          inputMode="numeric"
+          placeholder="Quality (1-5)"
+          value={form.quality_rating}
+          min={1}
+          max={5}
+          onChange={(e) => onChange({ ...form, quality_rating: e.target.value })}
+          className="w-28 bg-transparent text-sm outline-none min-h-[44px]"
+        />
+      </div>
+      <div className="ios-row justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm text-muted-foreground"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving || !form.meal_name}
+          className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg disabled:opacity-40"
+        >
+          {saving ? 'Saving…' : 'Add'}
+        </button>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Closes the last nutrition follow-up from PR #28: hydration logging and free-text day notes are now native to `/nutrition/today`, and the legacy back-door subtab inside `/nutrition/week` has been deleted along with all its dead state.

**Today page:** new `DayNoteSection` component sits above the "Mark day reviewed" CTA. Hydration is an ml input with `+250` / `+500` / `+750` quick-add buttons (sized to common pour amounts). Notes is a 2-row textarea. Both fields auto-save with a 600ms debounce via the existing `setDayNote` local-first mutation, so there's no Save button to remember and no chance of losing input on navigation.

**Week page:** the 937-line legacy component had a Today subtab acting as a back-door to hydration/notes. With those features now native to the new Today, the subtab + all its state (deviation editing, planned-meal logging, protein-target localStorage, dayBundle query, hydration/notes inputs) is deleted. The file is now 398 lines and only does the Week template editor — single responsibility, much easier to read.

## Verification

- `next build` clean
- `vitest run` 806/806 pass
- `tsc --noEmit` clean across `src/app/nutrition/`
- Existing `nutrition_day_notes` rows continue to render — same DB, same mutation path
- `/nutrition/week` route still works (verified build prerender)

## Test plan
- [x] Build + tests + types clean
- [x] Existing day_notes data migrates visually (no schema change — same row, same columns)
- [ ] Live test typing in Notes / tapping +500ml on the Today page (deferred to morning sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)