### PR TITLE
fix(cap): unblock Capacitor build by extracting nutrition types out of /app/api

### DIFF
--- a/scripts/ios-device-build.sh
+++ b/scripts/ios-device-build.sh
@@ -60,6 +60,7 @@ xcodebuild \
   -destination "platform=iOS,id=$DEVICE_ID" \
   -derivedDataPath build/ios-device \
   -allowProvisioningUpdates \
+  -allowProvisioningDeviceRegistration \
   -authenticationKeyPath "$KEY_PATH" \
   -authenticationKeyID "$KEY_ID" \
   -authenticationKeyIssuerID "$ISSUER_ID" \

--- a/src/app/api/nutrition/foods/route.ts
+++ b/src/app/api/nutrition/foods/route.ts
@@ -19,18 +19,10 @@ import { searchOpenFoodFacts, searchUsdaFdc } from '@/lib/food-search-remote';
  * food shows up as a Layer-1 hit on the next search.
  */
 
-export interface FoodResult {
-  source: 'local' | 'off' | 'usda';
-  food_name: string;
-  serving_size: { qty: number; unit: string } | null;
-  calories: number | null;
-  protein_g: number | null;
-  carbs_g: number | null;
-  fat_g: number | null;
-  nutrients: Record<string, unknown> | null;
-  external_id: string | null;
-  meta: { times_logged?: number; last_logged_at?: string } | null;
-}
+// Source of truth lives in src/lib/nutrition-history-types.ts so the
+// Capacitor build can import it from client code.
+export type { FoodResult } from '@/lib/nutrition-history-types';
+import type { FoodResult } from '@/lib/nutrition-history-types';
 
 interface CanonicalRow {
   food_name: string;

--- a/src/app/api/nutrition/history/route.ts
+++ b/src/app/api/nutrition/history/route.ts
@@ -12,15 +12,10 @@ interface AggRow {
   approved_status: string | null;
 }
 
-export interface HistoryDay {
-  date: string;
-  calories: number | null;
-  protein_g: number | null;
-  carbs_g: number | null;
-  fat_g: number | null;
-  log_count: number;
-  approved_status: 'pending' | 'approved';
-}
+// Re-exported from src/lib/nutrition-history-types.ts so the Capacitor build
+// (which moves src/app/api out of the tree) can still type-import it.
+export type { HistoryDay } from '@/lib/nutrition-history-types';
+import type { HistoryDay } from '@/lib/nutrition-history-types';
 
 function num(v: string | number | null | undefined): number | null {
   if (v == null) return null;

--- a/src/app/api/nutrition/summary/route.ts
+++ b/src/app/api/nutrition/summary/route.ts
@@ -23,17 +23,11 @@ interface TargetsRow {
   bands: MacroBands | null;
 }
 
-export interface SummaryDay {
-  date: string;
-  calories: number | null;
-  protein_g: number | null;
-  carbs_g: number | null;
-  fat_g: number | null;
-  hit_count: number;
-  target_count: number;
-  has_data: boolean;
-  approved_status: 'pending' | 'approved';
-}
+// Source of truth lives in src/lib/nutrition-history-types.ts so the
+// Capacitor build can import it from client code (cap build moves
+// src/app/api out of the tree before next build).
+export type { SummaryDay } from '@/lib/nutrition-history-types';
+import type { SummaryDay } from '@/lib/nutrition-history-types';
 
 function num(v: string | number | null | undefined): number | null {
   if (v == null) return null;

--- a/src/app/nutrition/history/page.tsx
+++ b/src/app/nutrition/history/page.tsx
@@ -8,7 +8,7 @@ import { rebirthJsonHeaders } from '@/lib/api/headers';
 import { useNutritionTargets } from '@/lib/useLocalDB-nutrition';
 import { computeDayAdherence, DEFAULT_BANDS } from '@/lib/adherence';
 import { formatDateLabel, todayLocal } from '@/lib/nutrition-time';
-import type { HistoryDay } from '@/app/api/nutrition/history/route';
+import type { HistoryDay } from '@/lib/nutrition-history-types';
 import type { MacroBands } from '@/db/local';
 
 const RANGES = ['7d', '30d', '90d', 'all'] as const;

--- a/src/app/nutrition/summary/page.tsx
+++ b/src/app/nutrition/summary/page.tsx
@@ -12,7 +12,7 @@ import {
   CartesianGrid,
 } from 'recharts';
 import { rebirthJsonHeaders } from '@/lib/api/headers';
-import type { SummaryDay } from '@/app/api/nutrition/summary/route';
+import type { SummaryDay } from '@/lib/nutrition-history-types';
 import type { MacroBands } from '@/db/local';
 
 const RANGES = ['week', 'month', 'all'] as const;

--- a/src/app/nutrition/today/AddFoodSheet.tsx
+++ b/src/app/nutrition/today/AddFoodSheet.tsx
@@ -8,7 +8,7 @@ import { logMeal } from '@/lib/mutations-nutrition';
 import { rebirthJsonHeaders } from '@/lib/api/headers';
 import { safeParseNumber } from '@/lib/nutrition-time';
 import type { MealSlot } from './MealSection';
-import type { FoodResult } from '@/app/api/nutrition/foods/route';
+import type { FoodResult } from '@/lib/nutrition-history-types';
 
 interface Props {
   open: boolean;

--- a/src/lib/food-search-remote.ts
+++ b/src/lib/food-search-remote.ts
@@ -9,7 +9,7 @@
  * tank the search response.
  */
 
-import type { FoodResult } from '@/app/api/nutrition/foods/route';
+import type { FoodResult } from '@/lib/nutrition-history-types';
 
 const OFF_TIMEOUT_MS = 1500;
 const USDA_TIMEOUT_MS = 1500;

--- a/src/lib/nutrition-history-types.ts
+++ b/src/lib/nutrition-history-types.ts
@@ -1,0 +1,40 @@
+// Shared client-safe types for the nutrition API surfaces.
+//
+// These live outside src/app/api so the Capacitor build (which moves
+// src/app/api out of the build tree before `next build`) can still type-import
+// them from client pages and lib helpers. The route files re-export from here.
+
+export interface HistoryDay {
+  date: string;
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  log_count: number;
+  approved_status: 'pending' | 'approved';
+}
+
+export interface SummaryDay {
+  date: string;
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  hit_count: number;
+  target_count: number;
+  has_data: boolean;
+  approved_status: 'pending' | 'approved';
+}
+
+export interface FoodResult {
+  source: 'local' | 'off' | 'usda';
+  food_name: string;
+  serving_size: { qty: number; unit: string } | null;
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  nutrients: Record<string, unknown> | null;
+  external_id: string | null;
+  meta: { times_logged?: number; last_logged_at?: string } | null;
+}


### PR DESCRIPTION
## Why

The Capacitor build (\`build:cap\`) moves \`src/app/api\` out of the tree before \`next build\` so it produces a static export with no server-side code. That broke the device build flow because three nutrition route files exported types that client pages were type-importing across that boundary:

- \`src/app/nutrition/history/page.tsx\` → \`HistoryDay\`
- \`src/app/nutrition/summary/page.tsx\` → \`SummaryDay\`
- \`src/app/nutrition/today/AddFoodSheet.tsx\` + \`src/lib/food-search-remote.ts\` → \`FoodResult\`

\`next build\` failed with \`Cannot find module '@/app/api/nutrition/.../route'\`.

## What

- Moved the three interfaces to \`src/lib/nutrition-history-types.ts\`. The route files re-export from there so server callers keep working; client code now imports from \`@/lib/...\` (independent of \`api/\`).
- Added \`-allowProvisioningDeviceRegistration\` to \`scripts/ios-device-build.sh\` so a freshly paired iPhone gets auto-registered with ASC via the API key on first build (instead of needing to be added in the developer portal manually).

## Test plan

- [x] \`npm run build:cap\` compiles cleanly (was failing on \`history\` then \`summary\`)
- [x] \`npm run build\` (the regular Next.js build) still compiles cleanly — server routes still see the type via the re-export
- [x] \`npx vitest run\` — all tests pass
- [ ] Device install verified after merge (blocked separately by Developer Mode being off on iPhone 17 — unrelated to this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)