### PR TITLE
feat(strength): RIR collection + effective-set weighting (Phase 2 + 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ Canonical muscle taxonomy: 18 slugs. Always use canonical slugs (`chest`, `lats`
 - **"Find a glute exercise"** → `find_exercises({ query: 'romanian deadlift', muscle_group: 'glutes' })` — `muscle_group` accepts canonical slugs OR legacy synonyms.
 
 Set quality:
-- Phase 1 ships set counts only. RIR (reps in reserve, 0–5) collection arrives in Phase 2; effective-set weighting in Phase 3.
 - A working set = `is_completed=true AND (reps>=1 OR duration_seconds>0)`. Drop sets count as 1 each. Each set credits BOTH primary AND secondary muscles (full credit, not fractional).
+- **RIR (Reps in Reserve, 0–5)** is collected per-set in the workout UI as a chip strip below each completed set row (0=failure, 5=5+ left). Stored on `workout_sets.rir`. NULL = not recorded.
+- **`effective_set_count`** (Phase 3) is the RIR-weighted variant on every `get_sets_per_muscle` row and `get_weekly_summary.by_muscle` row: RIR 0–3 counts 1.0, RIR 4 counts 0.5, RIR 5+ counts 0.0, RIR NULL counts 1.0 (charitable default until corpus exists). Until RIR is logged on most sets, `effective_set_count ≈ set_count`. The /feed Muscles This Week tile flags a muscle with a "JUNK" badge when `effective / set_count < 0.6` AND `set_count > 0` — meaning most logged sets were too far from failure to drive hypertrophy.
 
 `coverage` flag on `get_sets_per_muscle` rows: `'none'` means no exercise in the catalog tags this muscle (yet — the audit pass will populate). Until then those muscles can't accumulate sets. UI collapses them into a footer.

--- a/src/app/api/sync/changes/route.ts
+++ b/src/app/api/sync/changes/route.ts
@@ -357,6 +357,7 @@ function mapWorkoutSet(r: Record<string, unknown>) {
     min_target_reps: nullableNumber(r.min_target_reps),
     max_target_reps: nullableNumber(r.max_target_reps),
     rpe: nullableNumber(r.rpe),
+    rir: nullableNumber(r.rir),
     tag: r.tag ?? null,
     comment: r.comment ?? null,
     is_completed: Boolean(r.is_completed),

--- a/src/app/api/sync/push/route.ts
+++ b/src/app/api/sync/push/route.ts
@@ -141,16 +141,16 @@ async function pushWorkoutSet(r: Record<string, unknown>): Promise<void> {
     return;
   }
   await query(
-    `INSERT INTO workout_sets (uuid, workout_exercise_uuid, weight, repetitions, min_target_reps, max_target_reps, rpe, tag, comment, is_completed, is_pr, order_index, duration_seconds, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
+    `INSERT INTO workout_sets (uuid, workout_exercise_uuid, weight, repetitions, min_target_reps, max_target_reps, rpe, rir, tag, comment, is_completed, is_pr, order_index, duration_seconds, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW())
      ON CONFLICT (uuid) DO UPDATE SET
        weight = EXCLUDED.weight, repetitions = EXCLUDED.repetitions,
        min_target_reps = EXCLUDED.min_target_reps, max_target_reps = EXCLUDED.max_target_reps,
-       rpe = EXCLUDED.rpe, tag = EXCLUDED.tag, comment = EXCLUDED.comment,
+       rpe = EXCLUDED.rpe, rir = EXCLUDED.rir, tag = EXCLUDED.tag, comment = EXCLUDED.comment,
        is_completed = EXCLUDED.is_completed, is_pr = EXCLUDED.is_pr,
        order_index = EXCLUDED.order_index,
        duration_seconds = EXCLUDED.duration_seconds, updated_at = NOW()`,
-    [r.uuid, r.workout_exercise_uuid, r.weight, r.repetitions, r.min_target_reps, r.max_target_reps, r.rpe, r.tag, r.comment, r.is_completed, r.is_pr, r.order_index, r.duration_seconds ?? null],
+    [r.uuid, r.workout_exercise_uuid, r.weight, r.repetitions, r.min_target_reps, r.max_target_reps, r.rpe, r.rir ?? null, r.tag, r.comment, r.is_completed, r.is_pr, r.order_index, r.duration_seconds ?? null],
   );
 }
 

--- a/src/app/api/workout-exercises/[uuid]/sets/route.ts
+++ b/src/app/api/workout-exercises/[uuid]/sets/route.ts
@@ -49,6 +49,7 @@ export async function POST(
       weight: body.weight,
       repetitions: body.repetitions,
       rpe: body.rpe,
+      rir: body.rir,
       isCompleted: body.isCompleted,
     });
 
@@ -66,6 +67,7 @@ export async function POST(
       weight: body.weight,
       repetitions: body.repetitions,
       rpe: body.rpe,
+      rir: body.rir,
       tag: body.tag,
     });
 

--- a/src/app/workout/page.tsx
+++ b/src/app/workout/page.tsx
@@ -762,6 +762,7 @@ function SetRow({
   trackingMode,
   onUpdate,
   onUpdateDuration,
+  onUpdateRir,
   onDelete,
   allTimeBest1RM,
 }: {
@@ -771,6 +772,7 @@ function SetRow({
   trackingMode: 'reps' | 'time';
   onUpdate: (weUuid: string, setUuid: string, weight: number, reps: number) => Promise<void>;
   onUpdateDuration: (weUuid: string, setUuid: string, durationSeconds: number) => Promise<void>;
+  onUpdateRir: (setUuid: string, rir: number | null) => Promise<void>;
   onDelete: (setUuid: string) => Promise<void>;
   allTimeBest1RM?: number | null;
 }) {
@@ -889,9 +891,43 @@ function SetRow({
     </div>
   );
 
+  // RIR chip strip — visible only after the set is completed. Reps in Reserve
+  // 0–5 (0 = went to failure, 5 = 5+ left in tank). Tap to toggle/clear; pre-
+  // completion the strip is hidden to keep the input row uncluttered. Phase 3
+  // weights this for effective_set_count, but the data is collected here.
+  const rirStrip = completed ? (
+    <div className="flex items-center gap-1 pb-1.5 px-3 pl-10">
+      <span className="text-[10px] text-muted-foreground mr-1">RIR</span>
+      {[0, 1, 2, 3, 4, 5].map(n => {
+        const active = set.rir === n;
+        return (
+          <button
+            type="button"
+            key={n}
+            onClick={async () => {
+              await onUpdateRir(set.uuid, active ? null : n);
+            }}
+            className={
+              'w-6 h-6 rounded-full text-[11px] font-medium transition-colors ' +
+              (active
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-secondary text-muted-foreground hover:bg-primary/15')
+            }
+            aria-label={`RIR ${n}${active ? ' (selected — tap to clear)' : ''}`}
+          >
+            {n}
+          </button>
+        );
+      })}
+    </div>
+  ) : null;
+
   return (
     <SwipeToDelete onDelete={() => onDelete(set.uuid)}>
-      {inner}
+      <div>
+        {inner}
+        {rirStrip}
+      </div>
     </SwipeToDelete>
   );
 }
@@ -918,6 +954,7 @@ function SortableExerciseCard({
   onAddSet,
   onUpdateSet,
   onUpdateSetDuration,
+  onUpdateSetRir,
   onDeleteSet,
   onShowInfo,
 }: {
@@ -928,6 +965,7 @@ function SortableExerciseCard({
   onAddSet: () => void;
   onUpdateSet: (workoutExerciseUuid: string, setUuid: string, weight: number, reps: number) => Promise<void>;
   onUpdateSetDuration: (workoutExerciseUuid: string, setUuid: string, durationSeconds: number) => Promise<void>;
+  onUpdateSetRir: (setUuid: string, rir: number | null) => Promise<void>;
   onDeleteSet: (uuid: string) => Promise<void>;
   onShowInfo: () => void;
 }) {
@@ -1030,6 +1068,7 @@ function SortableExerciseCard({
               trackingMode={we.exercise?.tracking_mode ?? 'reps'}
               onUpdate={onUpdateSet}
               onUpdateDuration={onUpdateSetDuration}
+              onUpdateRir={onUpdateSetRir}
               onDelete={onDeleteSet}
               allTimeBest1RM={allTimeBest1RM}
             />
@@ -1290,6 +1329,7 @@ export default function WorkoutPage() {
               min_target_reps: s.min_target_reps,
               max_target_reps: s.max_target_reps,
               rpe: null,
+              rir: null,
               tag: s.tag as 'dropSet' | 'failure' | null,
               comment: s.comment,
               is_completed: false,
@@ -1383,6 +1423,10 @@ export default function WorkoutPage() {
     }
 
     setShowExercises(false);
+  };
+
+  const updateSetRir = async (setUuid: string, rir: number | null) => {
+    await mutUpdateSet(setUuid, { rir });
   };
 
   const updateSet = async (workoutExerciseUuid: string, setUuid: string, weight: number, reps: number) => {
@@ -1605,6 +1649,7 @@ export default function WorkoutPage() {
                       onAddSet={() => handleAddSet(we)}
                       onUpdateSet={updateSet}
                       onUpdateSetDuration={updateSetDuration}
+                      onUpdateSetRir={updateSetRir}
                       onDeleteSet={mutDeleteSet}
                       onShowInfo={() => setInfoExercise(we.exercise as unknown as Exercise)}
                     />

--- a/src/components/MusclesThisWeek.tsx
+++ b/src/components/MusclesThisWeek.tsx
@@ -65,9 +65,23 @@ function formatVolume(kg: number): string {
   return `${Math.round(kg)} kg`;
 }
 
+/**
+ * Junk-set warning fires when meaningful RIR data is present and most sets
+ * are too far from failure to drive hypertrophy. Phase 3 weighting:
+ *   effective_set_count / set_count < 0.6 AND set_count > 0
+ *
+ * NOTE: until the user logs RIR on most sets, the SQL fallback (RIR=NULL → 1.0)
+ * keeps effective ≈ set_count, so the warning stays silent. As RIR data
+ * accumulates, junk sets bring effective down and the badge surfaces.
+ */
+function isJunkWarning(setCount: number, effectiveSetCount: number): boolean {
+  return setCount > 0 && effectiveSetCount / setCount < 0.6;
+}
+
 interface MuscleTileProps {
   display_name: string;
   set_count: number;
+  effective_set_count: number;
   optimal_min: number;
   optimal_max: number;
   status: Status;
@@ -76,24 +90,42 @@ interface MuscleTileProps {
   expanded?: boolean;
 }
 
-function MuscleTile({ display_name, set_count, optimal_min, optimal_max, status, kg_volume, view, expanded }: MuscleTileProps) {
+function MuscleTile({ display_name, set_count, effective_set_count, optimal_min, optimal_max, status, kg_volume, view, expanded }: MuscleTileProps) {
   // Progress bar: fill = min(set_count / optimal_max, 1.2) capped, tick at min/max ratio.
   const fillRatio = Math.min(set_count / optimal_max, 1.2);
+  const effectiveFillRatio = Math.min(effective_set_count / optimal_max, 1.2);
   const tickRatio = optimal_min / optimal_max;
   const headline = view === 'sets' ? String(set_count) : formatVolume(kg_volume);
   const subline = view === 'sets' && set_count > 0 ? `${optimal_min}–${optimal_max} optimal` : '';
+  const junk = isJunkWarning(set_count, effective_set_count);
 
   return (
     <div className={`rounded-lg border p-3 flex flex-col gap-2 transition-colors ${statusBg(status)} ${expanded ? 'ring-1 ring-primary' : ''}`}>
       <div className="flex items-baseline justify-between gap-2">
-        <span className="text-xs font-medium text-foreground/80 truncate">{display_name}</span>
+        <span className="text-xs font-medium text-foreground/80 truncate flex items-center gap-1">
+          {display_name}
+          {view === 'sets' && junk && (
+            <span
+              className="text-[9px] font-bold px-1 leading-[14px] rounded-full text-rose-700 bg-rose-100 dark:text-rose-200 dark:bg-rose-950/60 border border-rose-300 dark:border-rose-800"
+              title={`Effective sets ${effective_set_count.toFixed(1)} / ${set_count} — most sets logged too far from failure to drive hypertrophy`}
+            >
+              JUNK
+            </span>
+          )}
+        </span>
         <span className="text-lg font-semibold tabular-nums text-foreground">{headline}</span>
       </div>
       {view === 'sets' && (
         <div className="relative h-1.5 bg-foreground/10 rounded-full overflow-hidden">
+          {/* Raw fill (full width) — slightly muted so the effective fill reads as the headline */}
+          <div
+            className={`absolute left-0 top-0 h-full rounded-full transition-[width] duration-300 ${statusBarFill(status)} opacity-40`}
+            style={{ width: `${Math.min(fillRatio, 1) * 100}%` }}
+          />
+          {/* Effective fill (overlaid full color). Equal to raw until RIR data exists. */}
           <div
             className={`absolute left-0 top-0 h-full rounded-full transition-[width] duration-300 ${statusBarFill(status)}`}
-            style={{ width: `${Math.min(fillRatio, 1) * 100}%` }}
+            style={{ width: `${Math.min(effectiveFillRatio, 1) * 100}%` }}
           />
           {/* tick at optimal_min */}
           <div
@@ -132,6 +164,7 @@ export function MusclesThisWeek({ setsByMuscle }: MusclesThisWeekProps) {
   const groups = PARENT_GROUP_ORDER.filter(g => byGroup.has(g.key)).map(g => {
     const children = byGroup.get(g.key)!;
     const totalSets = children.reduce((s, c) => s + c.set_count, 0);
+    const totalEffective = children.reduce((s, c) => s + c.effective_set_count, 0);
     const totalVolume = children.reduce((s, c) => s + c.kg_volume, 0);
     const sumMin = children.reduce((s, c) => s + c.optimal_min, 0);
     const sumMax = children.reduce((s, c) => s + c.optimal_max, 0);
@@ -140,6 +173,7 @@ export function MusclesThisWeek({ setsByMuscle }: MusclesThisWeekProps) {
       label: g.label,
       children,
       totalSets,
+      totalEffective,
       totalVolume,
       optimal_min: sumMin,
       optimal_max: sumMax,
@@ -181,6 +215,7 @@ export function MusclesThisWeek({ setsByMuscle }: MusclesThisWeekProps) {
             <MuscleTile
               display_name={g.label}
               set_count={g.totalSets}
+              effective_set_count={g.totalEffective}
               optimal_min={g.optimal_min}
               optimal_max={g.optimal_max}
               status={g.status}
@@ -200,6 +235,7 @@ export function MusclesThisWeek({ setsByMuscle }: MusclesThisWeekProps) {
                 key={child.slug}
                 display_name={child.display_name}
                 set_count={child.set_count}
+                effective_set_count={child.effective_set_count}
                 optimal_min={child.optimal_min}
                 optimal_max={child.optimal_max}
                 status={child.status}

--- a/src/db/local.ts
+++ b/src/db/local.ts
@@ -69,6 +69,8 @@ export interface LocalWorkoutSet extends SyncMeta {
   min_target_reps: number | null;
   max_target_reps: number | null;
   rpe: number | null;
+  /** Reps in Reserve (0–5). 0=failure, 5=5+ left. NULL=not recorded. */
+  rir: number | null;
   tag: 'dropSet' | 'failure' | null;
   comment: string | null;
   is_completed: boolean;
@@ -656,6 +658,12 @@ export class IronDB extends Dexie {
       await tx.table('exercises').clear();
       await tx.table('_meta').delete('exercises_hydrated_at');
     });
+
+    // v12: Reps in Reserve (mirrors Postgres migration 028).
+    // workout_sets.rir is purely additive — Dexie tolerates the undefined
+    // field on existing rows, sync overwrites with the server value (NULL
+    // for un-logged sets) on next pull. No upgrade hook needed.
+    this.version(12).stores(v11Stores);
   }
 }
 

--- a/src/db/migrations/028_rir_column.sql
+++ b/src/db/migrations/028_rir_column.sql
@@ -1,0 +1,32 @@
+-- Migration 028: Reps-in-Reserve (RIR) column on workout_sets.
+--
+-- Phase 2 of the sets-per-muscle initiative. Adds a separate `rir` column
+-- (0–5) for per-set effort capture. The pre-existing `rpe` column from
+-- migration 001 is left in place for back-compat; UI does not write to it.
+--
+-- RIR semantics:
+--   0 = went to failure (no reps left)
+--   1 = 1 rep left in the tank
+--   …
+--   5 = 5+ reps left (light enough not to count for hypertrophy)
+--   NULL = not recorded (default; treated as "in range" by Phase 3 weighting
+--          until a corpus of real data exists)
+--
+-- Phase 3 (queries.ts getWeekSetsPerMuscle) consumes this column to compute
+-- effective_set_count: RIR 0–3 = 1.0, RIR 4 = 0.5, RIR 5+ = 0.0, NULL = 1.0.
+
+ALTER TABLE workout_sets
+  ADD COLUMN IF NOT EXISTS rir INT;
+
+-- Constraint added separately so the migration is rerunnable: dropping +
+-- recreating an existing constraint with the same name is safe.
+ALTER TABLE workout_sets
+  DROP CONSTRAINT IF EXISTS workout_sets_rir_range;
+
+ALTER TABLE workout_sets
+  ADD CONSTRAINT workout_sets_rir_range
+  CHECK (rir IS NULL OR (rir BETWEEN 0 AND 5));
+
+COMMENT ON COLUMN workout_sets.rir IS
+  'Reps in Reserve (0-5). 0=failure, 5=5+ left. NULL=not recorded. '
+  'Phase 2 of sets-per-muscle plan; Phase 3 weights this for effective set counting.';

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -330,6 +330,7 @@ export async function logSet(data: {
   weight: number;
   repetitions: number;
   rpe?: number;
+  rir?: number | null;
   tag?: 'dropSet' | 'failure';
   orderIndex?: number;
 }): Promise<WorkoutSet> {
@@ -346,14 +347,15 @@ export async function logSet(data: {
 
   await query(`
     INSERT INTO workout_sets (
-      uuid, workout_exercise_uuid, weight, repetitions, rpe, tag, order_index, is_completed
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, true)
+      uuid, workout_exercise_uuid, weight, repetitions, rpe, rir, tag, order_index, is_completed
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true)
   `, [
     uuid,
     data.workoutExerciseUuid,
     data.weight,
     data.repetitions,
     data.rpe || null,
+    data.rir ?? null,
     data.tag || null,
     orderIndex,
   ]);
@@ -365,6 +367,7 @@ export async function updateSet(uuid: string, data: {
   weight?: number;
   repetitions?: number;
   rpe?: number;
+  rir?: number | null;
   tag?: 'dropSet' | 'failure' | null;
   isCompleted?: boolean;
   isPr?: boolean;
@@ -384,6 +387,10 @@ export async function updateSet(uuid: string, data: {
   if (data.rpe !== undefined) {
     fields.push(`rpe = $${++paramCount}`);
     values.push(data.rpe);
+  }
+  if (data.rir !== undefined) {
+    fields.push(`rir = $${++paramCount}`);
+    values.push(data.rir);
   }
   if (data.tag !== undefined) {
     fields.push(`tag = $${++paramCount}`);
@@ -1183,6 +1190,7 @@ export async function startWorkoutFromRoutine(routineUuid: string): Promise<Star
           min_target_reps: routineSet.min_repetitions ?? null,
           max_target_reps: routineSet.max_repetitions ?? null,
           rpe: null,
+          rir: null,
           tag: routineSet.tag ?? null,
           comment: routineSet.comment ?? null,
           is_completed: false,
@@ -1206,6 +1214,7 @@ export async function startWorkoutFromRoutine(routineUuid: string): Promise<Star
           min_target_reps: null,
           max_target_reps: null,
           rpe: null,
+          rir: null,
           tag: null,
           comment: null,
           is_completed: false,
@@ -1276,6 +1285,14 @@ export async function getWeekMuscleFrequency(): Promise<{ primary_muscles: strin
  * counts toward every muscle in the exercise's primary AND secondary arrays
  * (full credit, no fractional weighting).
  *
+ * Phase 3 also returns `effective_set_count` — RIR-weighted hypertrophy
+ * volume:
+ *   RIR 0–3 → weight 1.0 (close to failure, full hypertrophy stimulus)
+ *   RIR 4   → weight 0.5 (sub-stimulus; partial credit)
+ *   RIR 5+  → weight 0.0 (junk set; no hypertrophy contribution)
+ *   RIR NULL → weight 1.0 (not recorded; charitable default until corpus
+ *              of real data exists)
+ *
  *   coverage='none' → no exercise in the catalog tags this muscle at all.
  *                     Useful for collapsing always-zero buckets in UI.
  *   coverage='tagged' → at least one exercise in the catalog tags it.
@@ -1291,6 +1308,7 @@ export async function getWeekSetsPerMuscle(weekOffset: number = 0): Promise<{
   optimal_sets_max: number;
   display_order: number;
   set_count: number;
+  effective_set_count: number;
   kg_volume: number;
   coverage: 'none' | 'tagged';
 }[]> {
@@ -1307,6 +1325,7 @@ export async function getWeekSetsPerMuscle(weekOffset: number = 0): Promise<{
         ws.uuid AS set_uuid,
         ws.weight,
         ws.repetitions,
+        ws.rir,
         e.primary_muscles,
         e.secondary_muscles
       FROM workout_sets ws
@@ -1325,7 +1344,7 @@ export async function getWeekSetsPerMuscle(weekOffset: number = 0): Promise<{
       -- Explode each set into one row per muscle hit (primary AND secondary).
       -- DISTINCT-by-(set_uuid, muscle_slug) so a set hitting a muscle via
       -- both primary AND secondary doesn't double-count.
-      SELECT DISTINCT ws.set_uuid, v.muscle_slug, ws.weight, ws.repetitions
+      SELECT DISTINCT ws.set_uuid, v.muscle_slug, ws.weight, ws.repetitions, ws.rir
       FROM week_sets ws,
            LATERAL (
              SELECT jsonb_array_elements_text(
@@ -1338,6 +1357,16 @@ export async function getWeekSetsPerMuscle(weekOffset: number = 0): Promise<{
       SELECT
         muscle_slug,
         COUNT(DISTINCT set_uuid) AS set_count,
+        -- Effective sets — RIR-weighted hypertrophy volume.
+        --   RIR 0–3 = 1.0, RIR 4 = 0.5, RIR 5+ = 0.0, NULL = 1.0
+        COALESCE(SUM(
+          CASE
+            WHEN rir IS NULL THEN 1.0
+            WHEN rir <= 3    THEN 1.0
+            WHEN rir = 4     THEN 0.5
+            ELSE 0.0
+          END
+        ), 0)::numeric AS effective_set_count,
         COALESCE(
           SUM(weight * repetitions) FILTER (WHERE weight IS NOT NULL AND repetitions IS NOT NULL),
           0
@@ -1365,6 +1394,7 @@ export async function getWeekSetsPerMuscle(weekOffset: number = 0): Promise<{
       m.optimal_sets_max,
       m.display_order,
       COALESCE(ma.set_count, 0)::int                                AS set_count,
+      COALESCE(ma.effective_set_count, 0)::numeric                  AS effective_set_count,
       COALESCE(ma.kg_volume, 0)::numeric                            AS kg_volume,
       CASE WHEN mc.muscle_slug IS NULL THEN 'none' ELSE 'tagged' END AS coverage
     FROM muscles m
@@ -1381,6 +1411,7 @@ export async function getWeekSetsPerMuscle(weekOffset: number = 0): Promise<{
     optimal_sets_max: Number(r.optimal_sets_max),
     display_order: Number(r.display_order),
     set_count: Number(r.set_count),
+    effective_set_count: Number(r.effective_set_count),
     kg_volume: Number(r.kg_volume),
     coverage: r.coverage as 'none' | 'tagged',
   }));
@@ -1488,6 +1519,7 @@ export function parseWorkoutSet(row: DbRow): WorkoutSet {
     min_target_reps: row.min_target_reps as number | null,
     max_target_reps: row.max_target_reps as number | null,
     rpe: row.rpe ? parseFloat(row.rpe as string) : null,
+    rir: row.rir == null ? null : Number(row.rir),
     tag: row.tag as 'dropSet' | 'failure' | null,
     comment: row.comment as string | null,
     is_completed: Boolean(row.is_completed),

--- a/src/lib/api/feed-types.ts
+++ b/src/lib/api/feed-types.ts
@@ -53,6 +53,11 @@ export interface SetsByMuscleRow {
   display_name: string;
   parent_group: string;
   set_count: number;
+  /** RIR-weighted hypertrophy sets. RIR 0–3 = 1.0, RIR 4 = 0.5, RIR 5+ = 0.0,
+   *  NULL = 1.0 (charitable default until RIR data exists). UI surfaces a
+   *  junk-set warning when effective_set_count / set_count < 0.6 AND most
+   *  sets in the muscle's week have RIR logged. */
+  effective_set_count: number;
   optimal_min: number;
   optimal_max: number;
   display_order: number;

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -543,12 +543,13 @@ async function getWeeklySummary(args: Record<string, unknown> = {}) {
   const totalVolume = Math.round(workoutRows.reduce((sum, w) => sum + Number(w.total_volume), 0));
 
   // by_muscle = merged shape per /autoplan DX review. set_count is the headline
-  // metric (Schoenfeld 10–20); kg_volume kept alongside as legacy for callers
-  // that haven't migrated.
+  // metric (Schoenfeld 10–20); effective_set_count is the RIR-weighted variant
+  // (Phase 3); kg_volume kept alongside as legacy for callers that haven't migrated.
   const byMuscle = byMuscleRows.map(m => ({
     slug: m.slug,
     display_name: m.display_name,
     set_count: m.set_count,
+    effective_set_count: Math.round(m.effective_set_count * 10) / 10,
     optimal_min: m.optimal_sets_min,
     optimal_max: m.optimal_sets_max,
     status: muscleStatusOf(m.set_count, m.optimal_sets_min, m.optimal_sets_max),
@@ -603,6 +604,7 @@ async function getSetsPerMuscle(args: Record<string, unknown> = {}) {
     slug: string;
     display_name: string;
     set_count: number;
+    effective_set_count: number;
     optimal_min: number;
     optimal_max: number;
     status: 'zero' | 'under' | 'optimal' | 'over';
@@ -614,6 +616,7 @@ async function getSetsPerMuscle(args: Record<string, unknown> = {}) {
     slug: m.slug,
     display_name: m.display_name,
     set_count: m.set_count,
+    effective_set_count: Math.round(m.effective_set_count * 10) / 10,
     optimal_min: m.optimal_sets_min,
     optimal_max: m.optimal_sets_max,
     status: muscleStatusOf(m.set_count, m.optimal_sets_min, m.optimal_sets_max),
@@ -2752,6 +2755,7 @@ export const tools: MCPTool[] = [
       'Each row carries a coverage flag (none|tagged) — none means no exercise in the catalog tags this muscle yet (e.g. rhomboids until the audit pass tags them). ' +
       'Week boundaries (Monday start, local TZ) match get_weekly_summary. ' +
       'kg_volume is preserved on each row as a legacy metric — prefer set_count for hypertrophy questions. ' +
+      'effective_set_count is the RIR-weighted variant (Phase 3): RIR 0–3 counts 1.0, RIR 4 counts 0.5, RIR 5+ counts 0.0. RIR=NULL gets the charitable default of 1.0, so until RIR is collected on most sets the value will equal set_count. When effective < set_count by a meaningful margin, the user is leaving stimulus on the table (junk sets too far from failure). ' +
       'Pairs with list_muscles (taxonomy + optimal ranges) and get_weekly_summary (total volume + compliance). ' +
       'Use week_offset=0 for current week, -1 for last week.',
     inputSchema: {

--- a/src/lib/mutations.ts
+++ b/src/lib/mutations.ts
@@ -123,7 +123,7 @@ export async function removeExerciseFromWorkout(uuid: string): Promise<void> {
 
 export async function addSet(
   workout_exercise_uuid: string,
-  data: Partial<Pick<LocalWorkoutSet, 'weight' | 'repetitions' | 'min_target_reps' | 'max_target_reps' | 'rpe' | 'tag'>>,
+  data: Partial<Pick<LocalWorkoutSet, 'weight' | 'repetitions' | 'min_target_reps' | 'max_target_reps' | 'rpe' | 'rir' | 'tag'>>,
   order_index: number,
 ): Promise<string> {
   const id = genUUID();
@@ -135,6 +135,7 @@ export async function addSet(
     min_target_reps: data.min_target_reps ?? null,
     max_target_reps: data.max_target_reps ?? null,
     rpe: data.rpe ?? null,
+    rir: data.rir ?? null,
     tag: data.tag ?? null,
     comment: null,
     is_completed: false,

--- a/src/lib/server/summary-data.ts
+++ b/src/lib/server/summary-data.ts
@@ -86,6 +86,7 @@ export async function getSummaryData(): Promise<SummaryPayload> {
     display_name: r.display_name,
     parent_group: r.parent_group,
     set_count: r.set_count,
+    effective_set_count: r.effective_set_count,
     optimal_min: r.optimal_sets_min,
     optimal_max: r.optimal_sets_max,
     display_order: r.display_order,

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,9 @@ export interface WorkoutSet {
   repetitions: number | null;
   min_target_reps: number | null;
   max_target_reps: number | null;
-  rpe: number | null; // 7.0-10.0 by 0.5
+  rpe: number | null; // 7.0-10.0 by 0.5 (legacy; UI does not collect)
+  /** Reps in Reserve (0–5). 0=failure, 5=5+ left. NULL=not recorded. */
+  rir: number | null;
   tag: 'dropSet' | 'failure' | null;
   comment: string | null;
   is_completed: boolean;


### PR DESCRIPTION
## Summary

Phase 2 + 3 of the sets-per-muscle initiative, both shipped together.

**Phase 2 (collection):** RIR (Reps in Reserve, 0–5) per-set capture in the workout UI + DB column + sync wiring.
**Phase 3 (weighting):** \`effective_set_count\` field — RIR-weighted hypertrophy volume — surfaced in /feed and on \`get_sets_per_muscle\` / \`get_weekly_summary\` MCP tools, with a JUNK badge when most sets were too far from failure.

## Migration

**028_rir_column.sql** — \`ALTER TABLE workout_sets ADD COLUMN rir INT CHECK (rir BETWEEN 0 AND 5)\`. Already applied to prod (1753 existing rows get \`rir = NULL\`, treated as the charitable 1.0 weight until rewritten).

## Workout UI

A small RIR chip strip appears under each set row once the set is completed (hidden during input to keep the row uncluttered). Tap a chip to record 0–5 (0 = failure, 5 = 5+ left in tank). Tap the active chip again to clear back to NULL.

## RIR weighting (Phase 3)

\`getWeekSetsPerMuscle\` and the new \`effective_set_count\` field on \`get_sets_per_muscle\` + \`get_weekly_summary.by_muscle\`:

\`\`\`
RIR 0–3   → 1.0   (close to failure, full stimulus)
RIR 4     → 0.5   (sub-stimulus; partial credit)
RIR 5+    → 0.0   (junk set; no contribution)
RIR NULL  → 1.0   (charitable default until RIR data accumulates)
\`\`\`

Until RIR is logged on most sets, \`effective_set_count ≈ set_count\`, so existing dashboards and MCP consumers keep working without behavioural change. As RIR data accumulates, junk sets bring effective down and:

- The /feed Muscles This Week tile shows a layered progress bar (effective fill = full color, raw fill = muted) so junk-loaded muscles read visibly.
- A small JUNK badge appears on the muscle name when \`set_count > 0\` AND \`effective / set_count < 0.6\`.

## Files changed

- \`src/db/migrations/028_rir_column.sql\` (new)
- \`src/db/local.ts\` — Dexie v12 + LocalWorkoutSet.rir
- \`src/db/queries.ts\` — getWeekSetsPerMuscle CTE adds rir + effective_set_count, parseWorkoutSet pulls rir, logSet/updateSet accept rir
- \`src/types.ts\` — WorkoutSet.rir
- \`src/lib/mutations.ts\` — addSet/updateSet support rir
- \`src/app/api/workout-exercises/[uuid]/sets/route.ts\` — accepts rir
- \`src/app/api/sync/changes/route.ts\` — mapWorkoutSet includes rir
- \`src/app/api/sync/push/route.ts\` — INSERT/UPSERT writes rir
- \`src/app/workout/page.tsx\` — RIR chip strip in SetRow + onUpdateRir handler
- \`src/components/MusclesThisWeek.tsx\` — effective fill overlay + JUNK badge
- \`src/lib/api/feed-types.ts\` — SetsByMuscleRow.effective_set_count
- \`src/lib/server/summary-data.ts\` — wire through
- \`src/lib/mcp-tools.ts\` — by_muscle + get_sets_per_muscle return effective_set_count; tool description updated
- \`CLAUDE.md\` — strength workflow doc updated

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 873/873 pass
- [x] Migration 028 applied to prod, column verified
- [ ] Open the app on Chill, complete a set, tap RIR chips → persists, syncs back
- [ ] Log a few RIR-3 sets and a few RIR-5 sets in the same muscle, verify /feed shows the muted bar split + JUNK badge once enough RIR-5s land
- [ ] Tap RIR chip again to clear → returns to NULL on disk
- [ ] \`get_sets_per_muscle\` MCP tool returns effective_set_count alongside set_count

## Phase 2 / MCP scope note

Phase 2 deliberately does NOT add an MCP write surface for live \`workout_sets\` — there is no such tool today. The existing \`update_sets\` MCP tool targets routine templates (\`workout_routine_sets\`), not actual logged sets. RIR collection happens in the workout UI and via the API route. A future MCP tool for live-set logging is a separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)