### PR TITLE
ci: PR-level build + test gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Run the test suite before building. This catches regressions on
+      # main even if the PR Build workflow was bypassed (admin merges,
+      # skipped checks, paths-ignore overlap). The full vitest run is
+      # ~2s — cheap belt-and-suspenders.
+      - name: Test
+        run: npm run test
+
       - name: Pull Vercel environment
         run: npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
         env:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,37 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+      - 'docs/**'
+
+# Cancel a previous PR-build run on the same PR if a new push lands.
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `next build` runs the type-checker + ESLint + the production
+      # webpack/Turbopack pass. Catches the same lint errors that broke
+      # main last time (PRs #42, #43, #46) before merge instead of after.
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test


### PR DESCRIPTION
## Summary

CI/CD already deploys to Vercel on every push to main (`.github/workflows/deploy.yml`). What was missing: a **pre-merge** check that runs the same build against PRs. Without it, lint failures kept slipping into main and only got caught after the merge — leaving main broken until a hot-fix went out. PRs #42, #43, #46 all hit this pattern in the last 24h.

## Changes

- **New `pr-build.yml`** — fires on `pull_request` against main. Runs `npm ci` → `npm run build` (type-check + ESLint + Next production pass) → `npm run test`. PRs go red **before** merge if they would break main. Concurrency grouped per PR so only the latest push runs. `paths-ignore` matches the deploy workflow so README-only PRs skip the check.
- **`deploy.yml`** — also runs `npm run test` before the Vercel build. Belt-and-suspenders for any path that bypasses the PR check (admin merges, `paths-ignore` overlap). Vitest is ~2s, negligible.

## What this doesn't do

- Doesn't touch branch protection. Required-status-check enforcement is a deliberate separate step (settings UI). This PR makes the check **available** as a status; the user decides whether to mark it required.

## Test plan
- [x] Local `npm run build` passes
- [x] Local `npm run test` passes (943/943)
- [ ] On push of this PR, `PR Build` workflow runs and goes green
- [ ] After merge, `Deploy` workflow runs the new test step and deploys to `iron-swart.vercel.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)